### PR TITLE
Backport overlay styles from brochure site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add Login.gov-specific component configuration. ([#258])(https://github.com/18F/identity-style-guide/pull/258)
   - [Identifier component](https://designsystem.digital.gov/components/identifier/)
   - Link colors on dark backgrounds
+- Overlay: Updated visual appearance. ([#260](https://github.com/18F/identity-style-guide/pull/260))
 
 ## 6.2.0
 

--- a/src/scss/components/_header.scss
+++ b/src/scss/components/_header.scss
@@ -1,0 +1,7 @@
+.usa-overlay {
+  background: color('base-darker');
+
+  &.is-visible {
+    opacity: opacity(50);
+  }
+}

--- a/src/scss/packages/_components.scss
+++ b/src/scss/packages/_components.scss
@@ -8,6 +8,7 @@
 @import '../components/code';
 @import '../components/footer';
 @import '../components/general';
+@import '../components/header';
 @import '../components/hero';
 @import '../components/identifier';
 @import '../components/inputs';


### PR DESCRIPTION
**Why**: For consistent styling between projects.

Reference: https://github.com/18F/identity-site/blob/7484761/_sass/components/_nav.scss#L115-L122

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-backport-overlay/

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/136257932-8d48a0ff-42f4-4bc8-aece-536be68de542.png)|![after](https://user-images.githubusercontent.com/1779930/136257941-506d8bc1-6d8b-4bb7-bba1-d5ee8d50f998.png)
