### PR TITLE
LG-5247: Add form input hint styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - [Identifier component](https://designsystem.digital.gov/components/identifier/)
   - Link colors on dark backgrounds
 - Overlay: Updated visual appearance. ([#260](https://github.com/18F/identity-style-guide/pull/260))
+- Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
 
 ## 6.2.0
 

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -33,6 +33,17 @@ subnav:
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
 
+## Format constraints
+
+When enforcing a specific text input pattern, provide a hint in the form of an example.
+
+{% capture example %}
+<label for="kvgx" class="usa-label">Social Security number</label>
+<div id="kvgx-hint" class="usa-hint">Example: 000-123-4567</div>
+<input id="kvgx" type="text" class="usa-input" aria-describedby="kvgx-hint" pattern="^\d{3}-?\d{2}-?\d{4}$">
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
 ## Dates
 
 Three text fields are the easiest way for users to enter most dates.

--- a/src/scss/elements/form-controls/_all.scss
+++ b/src/scss/elements/form-controls/_all.scss
@@ -1,0 +1,1 @@
+@import 'global';

--- a/src/scss/elements/form-controls/_global.scss
+++ b/src/scss/elements/form-controls/_global.scss
@@ -1,0 +1,5 @@
+.usa-hint {
+  @include u-text('italic');
+  @include u-margin-top(0.5);
+  @include u-margin-bottom(1.5);
+}

--- a/src/scss/packages/_components.scss
+++ b/src/scss/packages/_components.scss
@@ -1,5 +1,11 @@
 @import '../uswds/packages/uswds-components';
 
+// Elements
+// -------------------------------------
+@import '../elements/form-controls/all';
+
+// Components
+// -------------------------------------
 @import '../components/accordions';
 @import '../components/alerts';
 @import '../components/banner';


### PR DESCRIPTION
**Why**: To increase the contrast between the label and hint.

Related Slack discussion: https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1634220766001700

**Live preview URL:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-hint-italic/components/form-fields/#format-constraints

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/137501114-0648b920-343b-4c8f-849c-0834fc521cf2.png)
