### PR TITLE
Drop browser tools from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ruby_browsers:
     docker:
-      - image: cimg/ruby:3.0.2-browsers
+      - image: cimg/ruby:2.7-browsers
         environment:
           BUNDLER_VERSION: 2.2.20
 


### PR DESCRIPTION
**Why**: It's quite time-consuming, because it installs multiple browsers and browser drivers. Our end-to-end tests use Puppeteer, which is capable of installing its own copy of Chromium. We also don't need browsers outside the end-to-end (accessibility) test build.

Same idea as: https://github.com/18F/identity-site/pull/710

![image](https://user-images.githubusercontent.com/1779930/138885477-8d3f9542-9209-47f5-b936-7a73be7474f6.png)