### PR TITLE
Add README section for configuring theme variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ In JavaScript, you can import named members of the JavaScript package. If you ar
 + accordion.on();
 ```
 
+### Theme Variables
+
+The Login.gov Design System configures USWDS theme variables to provide defaults designed to be used across all Login.gov sites. These should almost always work well out-of-the-box, and not require further configuration.
+
+If needed, you can extend these using [the documented process for configuring settings](https://designsystem.digital.gov/documentation/settings/), providing variables when importing the `uswds-core` package:
+
+```diff
+- @use 'uswds-core';
++ @use 'uswds-core' with (
++   $theme-body-font-size: 'sm'
++ );
+```
+
 ## License
 
 See [LICENSE](https://github.com/18F/identity-style-guide/blob/main/LICENSE) for licensing information.


### PR DESCRIPTION
Since it's worth reaffirming that the design system already preconfigures settings, as well as anticipate that it may be necessary to configure in some cases ([example](https://github.com/18F/identity-idp/pull/8093/files#diff-2ffaf854e681b9e2cdfb8af6fb64a607d0580b978900873f2988d45d1161fcfa)).