### PR TITLE
Prepare repository rename "identity-style-guide"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ commands:
 
 jobs:
   lints:
-    working_directory: ~/identity-style-guide
     executor: ruby_browsers
     steps:
       - checkout
@@ -57,7 +56,6 @@ jobs:
           name: Lint JavaScript, Sass, and lockfiles
           command: make lint
   integration:
-    working_directory: ~/identity-style-guide
     executor: ruby_browsers
     environment:
       SKIP_VISUAL_REGRESSION_TEST: true
@@ -69,7 +67,6 @@ jobs:
           name: Run jest integration test
           command: npm test
   visual-regression:
-    working_directory: ~/identity-style-guide
     executor: ruby_browsers
     environment:
       ONLY_VISUAL_REGRESSION_TEST: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,132 +26,132 @@
 
 ### Improvements
 
-- Add new "Big" variant of Dropdown component. ([#328](https://github.com/18F/identity-style-guide/pull/328))
+- Add new "Big" variant of Dropdown component. ([#328](https://github.com/18F/identity-design-system/pull/328))
 
 ## 6.6.0
 
 ### Improvements
 
-- Add new "Big" variants of Text Input and Textarea components. ([#326](https://github.com/18F/identity-style-guide/pull/326))
-- Update Text Input styling to adhere to design specification. ([#325](https://github.com/18F/identity-style-guide/pull/325))
+- Add new "Big" variants of Text Input and Textarea components. ([#326](https://github.com/18F/identity-design-system/pull/326))
+- Update Text Input styling to adhere to design specification. ([#325](https://github.com/18F/identity-design-system/pull/325))
 
 ## 6.5.0
 
 ### Improvements
 
-- Increase line-height for accordion heading content to improve readability. ([#316](https://github.com/18F/identity-style-guide/pull/316))
+- Increase line-height for accordion heading content to improve readability. ([#316](https://github.com/18F/identity-design-system/pull/316))
 
 ## 6.4.2
 
 ### Dependencies
 
-- Update USWDS from v2.13.2 to 2.13.3. ([#312](https://github.com/18F/identity-style-guide/pull/312))
+- Update USWDS from v2.13.2 to 2.13.3. ([#312](https://github.com/18F/identity-design-system/pull/312))
 
 ### Improvements
 
-- Add styles and markdown content for selected and disabled radios and checkboxes. ([#313](https://github.com/18F/identity-style-guide/pull/313))
+- Add styles and markdown content for selected and disabled radios and checkboxes. ([#313](https://github.com/18F/identity-design-system/pull/313))
 
 ## 6.4.1
 
 ### Bug Fixes
 
-- Fix an issue where search field submit buttons would not show text at small viewport sizes. ([#311](https://github.com/18F/identity-style-guide/pull/311))
+- Fix an issue where search field submit buttons would not show text at small viewport sizes. ([#311](https://github.com/18F/identity-design-system/pull/311))
 
 ## 6.4.0
 
 ### Deprecation Notice
 
-- The `alerts/success-badge.svg` image will be removed in a future major version. Use `alerts/success.svg` instead. ([#306](https://github.com/18F/identity-style-guide/pull/306))
+- The `alerts/success-badge.svg` image will be removed in a future major version. Use `alerts/success.svg` instead. ([#306](https://github.com/18F/identity-design-system/pull/306))
 
 ### Improvements
 
-- Improve appearance of illustrated tile checkboxes and radio buttons. ([#309](https://github.com/18F/identity-style-guide/pull/309))
+- Improve appearance of illustrated tile checkboxes and radio buttons. ([#309](https://github.com/18F/identity-design-system/pull/309))
 
 ### Bug Fixes
 
-- Use correct "Success" green color for `alerts/unphishable.svg` icon. ([#306](https://github.com/18F/identity-style-guide/pull/306))
+- Use correct "Success" green color for `alerts/unphishable.svg` icon. ([#306](https://github.com/18F/identity-design-system/pull/306))
 
 ### Optimization
 
-- Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-style-guide/pull/300))
-- Remove duplicate styles. ([#301](https://github.com/18F/identity-style-guide/pull/301))
-- Reconcile redundant focus styles with U.S. Web Design System. ([#302](https://github.com/18F/identity-style-guide/pull/302))
-- Remove documentation site styles from design system artifact. ([#305](https://github.com/18F/identity-style-guide/pull/305))
-- Reduce size of SVG images. ([#307](https://github.com/18F/identity-style-guide/pull/307))
+- Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-design-system/pull/300))
+- Remove duplicate styles. ([#301](https://github.com/18F/identity-design-system/pull/301))
+- Reconcile redundant focus styles with U.S. Web Design System. ([#302](https://github.com/18F/identity-design-system/pull/302))
+- Remove documentation site styles from design system artifact. ([#305](https://github.com/18F/identity-design-system/pull/305))
+- Reduce size of SVG images. ([#307](https://github.com/18F/identity-design-system/pull/307))
 
 ### Dependencies
 
-- Update USWDS from v2.13.1 to 2.13.2. ([#304](https://github.com/18F/identity-style-guide/pull/304))
-- Update dependencies to resolve vulnerability advisories. ([#308](https://github.com/18F/identity-style-guide/pull/308))
+- Update USWDS from v2.13.1 to 2.13.2. ([#304](https://github.com/18F/identity-design-system/pull/304))
+- Update dependencies to resolve vulnerability advisories. ([#308](https://github.com/18F/identity-design-system/pull/308))
 
 ## 6.3.3
 
 ### Bug Fixes
 
-- Changing the radio tile image size from 1rem to 1.5rem. ([#299](https://github.com/18F/identity-style-guide/pull/299))
+- Changing the radio tile image size from 1rem to 1.5rem. ([#299](https://github.com/18F/identity-design-system/pull/299))
 
 ## 6.3.2
 
 ### Improvements
 
-- Line height calculations are improved such that the [desired token size](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/theme/_uswds-theme-typography.scss#L363-L371) will always apply regardless of font family or scale. ([#291](https://github.com/18F/identity-style-guide/pull/291))
+- Line height calculations are improved such that the [desired token size](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/theme/_uswds-theme-typography.scss#L363-L371) will always apply regardless of font family or scale. ([#291](https://github.com/18F/identity-design-system/pull/291))
   - In the case of headings, line-height will fall back to the configured body line-height if the resulting actual line-height would be smaller than body content when using the heading scale.
-- Body font size has been increased slightly to restore an effective font size of 1rem. ([#292](https://github.com/18F/identity-style-guide/pull/292))
-- The Process List component no longer applies vertical padding which would affect its layout relative to surrounding content. ([#290](https://github.com/18F/identity-style-guide/pull/290))
-- Input hint text is no longer italicized. ([#293](https://github.com/18F/identity-style-guide/pull/293))
-- New variation of checkbox and radio button tiles with illustrations is added to form fields. ([#296](https://github.com/18F/identity-style-guide/pull/296))
+- Body font size has been increased slightly to restore an effective font size of 1rem. ([#292](https://github.com/18F/identity-design-system/pull/292))
+- The Process List component no longer applies vertical padding which would affect its layout relative to surrounding content. ([#290](https://github.com/18F/identity-design-system/pull/290))
+- Input hint text is no longer italicized. ([#293](https://github.com/18F/identity-design-system/pull/293))
+- New variation of checkbox and radio button tiles with illustrations is added to form fields. ([#296](https://github.com/18F/identity-design-system/pull/296))
 
 ## 6.3.1
 
 ### Bug Fixes
 
-- Improve vertical spacing in heading of Process List item spanning multiple lines. ([#288](https://github.com/18F/identity-style-guide/pull/288))
-- Fix external link icon margin when followed by additional text content. ([#289](https://github.com/18F/identity-style-guide/pull/289))
+- Improve vertical spacing in heading of Process List item spanning multiple lines. ([#288](https://github.com/18F/identity-design-system/pull/288))
+- Fix external link icon margin when followed by additional text content. ([#289](https://github.com/18F/identity-design-system/pull/289))
 
 ## 6.3.0
 
 ### New Features
 
-- Field validation success is added to form validation. ([#265](https://github.com/18F/identity-style-guide/pull/265))
-- Added custom styling for the Process List component. ([#279](https://github.com/18F/identity-style-guide/pull/279))
+- Field validation success is added to form validation. ([#265](https://github.com/18F/identity-design-system/pull/265))
+- Added custom styling for the Process List component. ([#279](https://github.com/18F/identity-design-system/pull/279))
 
 ### Improvements
 
-- The default font is now Public Sans for both headings and body copy. This is not being considered a breaking change, as it is the new default guidance. To preserve existing font settings to allow more time to migrate, set `$theme-font-type-sans: 'source-sans-pro';` and `$theme-font-type-serif: 'merriweather';`. ([#264](https://github.com/18F/identity-style-guide/pull/264))
-- Add Login.gov-specific component configuration. ([#258](https://github.com/18F/identity-style-guide/pull/258))
+- The default font is now Public Sans for both headings and body copy. This is not being considered a breaking change, as it is the new default guidance. To preserve existing font settings to allow more time to migrate, set `$theme-font-type-sans: 'source-sans-pro';` and `$theme-font-type-serif: 'merriweather';`. ([#264](https://github.com/18F/identity-design-system/pull/264))
+- Add Login.gov-specific component configuration. ([#258](https://github.com/18F/identity-design-system/pull/258))
   - [Identifier component](https://designsystem.digital.gov/components/identifier/)
   - Link colors on dark backgrounds
-- The default line-height is now set to 1.5. This is not being considered a breaking change, as it is the new default guidance. To preserve existing font settings to allow more time to migrate, set `$theme-body-line-height: 6`. ([#283](https://github.com/18F/identity-style-guide/pull/283))
-- Overlay is now shown with a lighter backdrop color. ([#260](https://github.com/18F/identity-style-guide/pull/260))
-- Form Dropdown is now more visually consistent with other form fields. ([#263](https://github.com/18F/identity-style-guide/pull/263))
-- Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
-- Icons for form validation errors are aligned to the top. ([#265](https://github.com/18F/identity-style-guide/pull/265))
-- The tile variant of checkboxes and radio buttons have a slightly increased font size. ([#281](https://github.com/18F/identity-style-guide/pull/281))
-- Checkbox and radio labels which span multiple lines should now appear with a consistent line height relative to surrounding body copy. ([#283](https://github.com/18F/identity-style-guide/pull/283))
-- Search will now show full text labels at all sizes, and uses standardized font tokens. ([#259](https://github.com/18F/identity-style-guide/pull/259))
+- The default line-height is now set to 1.5. This is not being considered a breaking change, as it is the new default guidance. To preserve existing font settings to allow more time to migrate, set `$theme-body-line-height: 6`. ([#283](https://github.com/18F/identity-design-system/pull/283))
+- Overlay is now shown with a lighter backdrop color. ([#260](https://github.com/18F/identity-design-system/pull/260))
+- Form Dropdown is now more visually consistent with other form fields. ([#263](https://github.com/18F/identity-design-system/pull/263))
+- Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-design-system/pull/262))
+- Icons for form validation errors are aligned to the top. ([#265](https://github.com/18F/identity-design-system/pull/265))
+- The tile variant of checkboxes and radio buttons have a slightly increased font size. ([#281](https://github.com/18F/identity-design-system/pull/281))
+- Checkbox and radio labels which span multiple lines should now appear with a consistent line height relative to surrounding body copy. ([#283](https://github.com/18F/identity-design-system/pull/283))
+- Search will now show full text labels at all sizes, and uses standardized font tokens. ([#259](https://github.com/18F/identity-design-system/pull/259))
 
 ### Bug Fixes
 
-- Fix an issue where `.usa-input--error` would apply the incorrect border color unless also accompanied by `.usa-input`, `.usa-textarea`, or `.usa-select`. ([#275](https://github.com/18F/identity-style-guide/pull/275))
+- Fix an issue where `.usa-input--error` would apply the incorrect border color unless also accompanied by `.usa-input`, `.usa-textarea`, or `.usa-select`. ([#275](https://github.com/18F/identity-design-system/pull/275))
 
 ### Dependencies
 
-- Upgraded USWDS from v2.12.1 to v2.13.1 (see [release notes](https://github.com/uswds/uswds/releases)) ([#269](https://github.com/18F/identity-style-guide/pull/269), [#277](https://github.com/18F/identity-style-guide/pull/277), [#280](https://github.com/18F/identity-style-guide/pull/280))
+- Upgraded USWDS from v2.12.1 to v2.13.1 (see [release notes](https://github.com/uswds/uswds/releases)) ([#269](https://github.com/18F/identity-design-system/pull/269), [#277](https://github.com/18F/identity-design-system/pull/277), [#280](https://github.com/18F/identity-design-system/pull/280))
 
 ## 6.2.0
 
 ### New Features
 
-- All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements. ([#247](https://github.com/18F/identity-style-guide/pull/247))
+- All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements. ([#247](https://github.com/18F/identity-design-system/pull/247))
   - Note: Since the design system is meant to be an opinionated set of smart defaults, it's recommended to use restraint with variable customization, or at least consider when it may be more appropriate to adjust a setting from the design system itself in order to maintain consistency across projects.
-- Responsive variants of width utility classes are now enabled. ([#248](https://github.com/18F/identity-style-guide/pull/248))
+- Responsive variants of width utility classes are now enabled. ([#248](https://github.com/18F/identity-design-system/pull/248))
 
 ### Improvements
 
-- Navbar link text is no longer uppercase. ([#249](https://github.com/18F/identity-style-guide/pull/249))
-- Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics. ([#251](https://github.com/18F/identity-style-guide/pull/251))
-- Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed. ([#255](https://github.com/18F/identity-style-guide/pull/255))
-- Focus styles for links and unstyled buttons are now the same. ([#253](https://github.com/18F/identity-style-guide/pull/253))
+- Navbar link text is no longer uppercase. ([#249](https://github.com/18F/identity-design-system/pull/249))
+- Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics. ([#251](https://github.com/18F/identity-design-system/pull/251))
+- Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed. ([#255](https://github.com/18F/identity-design-system/pull/255))
+- Focus styles for links and unstyled buttons are now the same. ([#253](https://github.com/18F/identity-design-system/pull/253))
 
 ## 6.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Before starting, make sure that all changes intended for release should be merge
    - Consider: In the files listed, are there any that should or shouldn't be included? Does the version match what you expect?
 7. If everything looks alright, continue with publishing by running `npm publish`.
 8. Push your release branch to the GitHub repository and open a pull request.
-9. Once approved and merged, create a new release on the [GitHub "Releases" page](https://github.com/18F/identity-style-guide/releases).
+9. Once approved and merged, create a new release on the [GitHub "Releases" page](https://github.com/18F/identity-design-system/releases).
    - Use `main` as the target.
    - The release version should match the version just published to `npm` (for example, `v2.1.5`).
    - Use the version name as the release title.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Login.gov Design System is an extension of the [U.S. Web Design System](https://designsystem.digital.gov/) used on Login.gov sites to consistently identify the Login.gov brand.
 
-This documentation describes how to use the Login.gov Design System in a new project. Read [CONTRIBUTING.md](https://github.com/18F/identity-style-guide/blob/main/CONTRIBUTING.md) to learn more about contributing to the design system itself.
+This documentation describes how to use the Login.gov Design System in a new project. Read [CONTRIBUTING.md](https://github.com/18F/identity-design-system/blob/main/CONTRIBUTING.md) to learn more about contributing to the design system itself.
 
 ## Installation
 
@@ -89,4 +89,4 @@ If needed, you can extend these using [the documented process for configuring se
 
 ## License
 
-See [LICENSE](https://github.com/18F/identity-style-guide/blob/main/LICENSE) for licensing information.
+See [LICENSE](https://github.com/18F/identity-design-system/blob/main/LICENSE) for licensing information.

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Login.gov Design System
 description: A place for designers and developers to see components available for use on Login.gov sites.
-github_repo_url: https://github.com/18F/identity-style-guide
+github_repo_url: https://github.com/18F/identity-design-system
 url: https://design.login.gov
 domain: design.login.gov
 

--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -3,7 +3,7 @@
   {% assign stylesheet = include.component | prepend: 'usa-' %}
 {% endunless %}
 {% assign uswds_url = include.component | append: '/' | prepend: 'https://designsystem.digital.gov/components/' %}
-{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-style-guide/blob/main/src/scss/packages/_' %}
+{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-design-system/blob/main/src/scss/packages/_' %}
 
 [View USWDS component for guidance]({{ uswds_url }}){: .usa-link--external}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ lead: >
           The key to a strong brand <br>is <span class="text-accent-cool">consistency</span>.
         </div>
         <p class="usa-intro">{{ page.lead }}</p>
-        <a href="https://github.com/18F/identity-style-guide#configuring-for-development" class="usa-button usa-button--big">See installation instructions on GitHub</a>
+        <a href="https://github.com/18F/identity-design-system#configuring-for-development" class="usa-button usa-button--big">See installation instructions on GitHub</a>
       </div>
     </div>
   </div>
@@ -46,7 +46,7 @@ The {{ site.title }} is built using the [U.S. Web Design System](https://designs
 
 # A work in progress
 
-The latest version is <strong class="text-no-wrap">{{ site.package_json.this_version }}</strong> which uses <strong class="text-no-wrap">uswds@{{ site.package_json['@uswds/uswds_version'] }}</strong>. Spot an issue? We’d love to hear about it [on GitHub](https://github.com/18F/identity-style-guide/issues).
+The latest version is <strong class="text-no-wrap">{{ site.package_json.this_version }}</strong> which uses <strong class="text-no-wrap">uswds@{{ site.package_json['@uswds/uswds_version'] }}</strong>. Spot an issue? We’d love to hear about it [on GitHub](https://github.com/18F/identity-design-system/issues).
 
 </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/18F/identity-style-guide.git"
+    "url": "git+https://github.com/18F/identity-design-system.git"
   },
   "author": "18F",
   "license": "CC0-1.0",
@@ -55,9 +55,9 @@
     "npm": ">6"
   },
   "bugs": {
-    "url": "https://github.com/18F/identity-style-guide/issues"
+    "url": "https://github.com/18F/identity-design-system/issues"
   },
-  "homepage": "https://github.com/18F/identity-style-guide#readme",
+  "homepage": "https://github.com/18F/identity-design-system#readme",
   "dependencies": {
     "@uswds/uswds": "^3.4.1"
   },


### PR DESCRIPTION
This updates internal code references to the GitHub repository.

Next steps:

- Rename repository in Settings
- Replace site in Cloud.gov Pages