### PR TITLE
Fix header navigation current link styling regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ### Bug Fixes
 
-- Fix header navigation current link styling regression in 7.0.0 release.
+- Fix header navigation current link styling regression in 7.0.0 release. ([#352](https://github.com/18F/identity-design-system/pull/352))
+
+### Breaking Changes for Undocumented APIs
+
+_Note:_ While these are backwards-incompatible changes, the major version is not being changed because they impact features which were never part of a publicly-documented API.
+
+- Remove `.usa-sidenav--sticky` CSS class. ([#352](https://github.com/18F/identity-design-system/pull/352))
 
 ## 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fix header navigation current link styling regression in 7.0.0 release. ([#352](https://github.com/18F/identity-design-system/pull/352))
+- Fix dark background sections to show heading text as white. ([#352](https://github.com/18F/identity-design-system/pull/352))
 
 ### Breaking Changes for Undocumented APIs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix header navigation current link styling regression in 7.0.0 release.
+
 ## 7.0.0
 
 ### Breaking Changes

--- a/docs/_components/side-navigation.md
+++ b/docs/_components/side-navigation.md
@@ -9,13 +9,13 @@ lead: >
 {% capture example %}
 <nav aria-label="Secondary navigation" class="tablet:grid-col-4">
   <ul class="usa-sidenav">
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="" class="usa-current">Current page</a>
     </li>
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="">Parent link</a>
     </li>
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="">Parent link</a>
     </li>
   </ul>
@@ -28,7 +28,7 @@ lead: >
 {% capture example %}
 <nav aria-label="Secondary navigation" class="tablet:grid-col-4">
   <ul class="usa-sidenav">
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="" class="usa-current">Current page</a>
       <ul class="usa-sidenav__sublist">
         <li class="usa-sidenav__item">
@@ -39,7 +39,7 @@ lead: >
         </li>
       </ul>
     </li>
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="">Parent link</a>
     </li>
   </ul>
@@ -52,7 +52,7 @@ lead: >
 {% capture example %}
 <nav aria-label="Secondary navigation" class="tablet:grid-col-4">
   <ul class="usa-accordion usa-sidenav">
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="" class="usa-current">Current page</a>
       <ul class="usa-sidenav__sublist">
         <li class="usa-sidenav__item">
@@ -71,7 +71,7 @@ lead: >
         </li>
       </ul>
     </li>
-    <li class="usa-sidenav__item usa-parent">
+    <li class="usa-sidenav__item">
       <a href="">Parent link</a>
     </li>
   </ul>

--- a/docs/_includes/nav/link-item.html
+++ b/docs/_includes/nav/link-item.html
@@ -1,5 +1,5 @@
 {% assign is_current_page = include.link.href | eq: page.url -%}
-<a href="{{ include.link.href }}" class="{% if is_current_page %}usa-current{% endif %}">
+<a href="{{ include.link.href }}" class="{% if is_current_page %}usa-current{% endif %} usa-nav__link">
   <span>
     {{ include.link.text | smartify }}
   </span>

--- a/docs/_includes/nav/page-item.html
+++ b/docs/_includes/nav/page-item.html
@@ -1,5 +1,5 @@
 {% assign is_current_page = true | if_is_current_page: include.jekyll_page, include.highlight_collection_when_is_current -%}
-<a href="{{ include.jekyll_page.url | relative_url }}" class="{% if is_current_page %}usa-current{% endif %}">
+<a href="{{ include.jekyll_page.url | relative_url }}" class="{% if is_current_page %}usa-current{% endif %} usa-nav__link">
   <span>
     {{ include.text | default: include.jekyll_page.title | smartify }}
   </span>

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -35,7 +35,7 @@ layout: base
           {{ content }}
         </div>
 
-        <aside class="grid-col-3 tablet:display-none padding-top-4">
+        <aside class="grid-col-12 tablet:display-none padding-top-4">
           <nav>
             <ul class="usa-sidenav">
               {%

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.0.0",
+  "version": "7.0.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "7.0.0",
+      "version": "7.0.1-beta.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.0.0",
+  "version": "7.0.1-beta.1",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/packages/_usa-header.scss
+++ b/src/scss/packages/_usa-header.scss
@@ -4,8 +4,7 @@
 // Header
 // ---------------------------------
 
-.usa-header + .usa-section,
-.usa-header + main {
+.usa-header + .usa-section--dark {
   @include at-media($theme-header-min-width) {
     border-top: none;
   }

--- a/src/scss/packages/_usa-header.scss
+++ b/src/scss/packages/_usa-header.scss
@@ -51,6 +51,14 @@
     }
   }
 
+  .usa-navbar {
+    @include at-media($theme-header-min-width) {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+
   .usa-nav {
     @include at-media($theme-header-min-width) {
       border-top: none;

--- a/src/scss/packages/_usa-header.scss
+++ b/src/scss/packages/_usa-header.scss
@@ -4,6 +4,13 @@
 // Header
 // ---------------------------------
 
+.usa-header + .usa-section,
+.usa-header + main {
+  @include at-media($theme-header-min-width) {
+    border-top: none;
+  }
+}
+
 .usa-logo img {
   display: block;
   height: units(2);

--- a/src/scss/packages/_usa-header.scss
+++ b/src/scss/packages/_usa-header.scss
@@ -1,7 +1,31 @@
 @use 'uswds-core' as *;
 @forward './usa-header/index';
 
-$header-height: 10;
+// Header
+// ---------------------------------
+
+.usa-logo img {
+  display: block;
+  height: units(2);
+
+  @include at-media($theme-header-min-width) {
+    height: units(3);
+  }
+}
+
+.usa-logo__text {
+  @include at-media-max($theme-header-min-width) {
+    @include u-font-size($theme-header-font-family, 3);
+    padding-left: 17px;
+  }
+
+  @include at-media($theme-header-min-width) {
+    @include u-font-size($theme-header-font-family, 4);
+    padding-left: 27px;
+  }
+
+  color: color('secondary');
+}
 
 .usa-overlay {
   background: color('base-darker');
@@ -11,72 +35,36 @@ $header-height: 10;
   }
 }
 
-// Header navigation
+// usa-header--extended
 // ---------------------------------
 
-.usa-header--extended,
-.usa-header--basic {
+.usa-header--extended {
   .usa-logo {
-    @include at-media-max($theme-header-min-width) {
-      font-size: unset;
-      flex: unset;
-    }
-
     @include at-media($theme-header-min-width) {
-      font-size: unset;
-      margin: 0;
-    }
-
-    line-height: units(2);
-  }
-
-  .usa-navbar {
-    @include at-media-max($theme-header-min-width) {
-      border-bottom: units(1px) solid color('base-light');
-      justify-content: space-between;
-    }
-
-    @include at-media($theme-header-min-width) {
-      display: flex;
-      align-items: center;
-      height: units($header-height);
-    }
-  }
-}
-
-.usa-header {
-  + .usa-section,
-  + main {
-    @include at-media($theme-header-min-width) {
-      border-top: units(1px) solid color('base-light');
-    }
-  }
-}
-
-// Header navigation for basic
-// ---------------------------------
-
-.usa-header--basic {
-  .usa-nav-container {
-    @include at-media($theme-header-min-width) {
-      align-items: center;
+      @include u-margin-y(2.5);
     }
   }
 
   .usa-nav {
     @include at-media($theme-header-min-width) {
-      padding: 0;
+      border-top: none;
     }
   }
-}
 
-// Header navigation for extended
-// ---------------------------------
+  .usa-nav__primary {
+    @include at-media($theme-header-min-width) {
+      margin-left: units(-1.5);
+    }
+  }
 
-.usa-header--extended .usa-nav {
   @include at-media($theme-header-min-width) {
-    border-top: 0;
-    padding: 0;
-    width: 100%;
+    .usa-nav__primary-item > .usa-current,
+    .usa-nav__primary-item > .usa-nav__link:hover {
+      &::after {
+        background-color: color('secondary');
+        left: units(1.5);
+        right: units(1.5);
+      }
+    }
   }
 }

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -50,6 +50,17 @@
   }
 }
 
+// Navigation dropdowns
+// ---------------------------------
+
+.usa-nav__submenu {
+  @include at-media-max($theme-header-min-width) {
+    .usa-nav__submenu-item + .usa-nav__submenu-item {
+      border-top: none;
+    }
+  }
+}
+
 // Navigation close button
 // ---------------------------------
 

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -2,8 +2,6 @@
 @use './usa-nav/index' as usa-nav;
 @forward './usa-nav/index';
 
-$header-height: 10;
-
 .usa-nav__primary {
   @include at-media-max($theme-header-min-width) {
     a:not(.usa-button) {

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -42,6 +42,12 @@
       }
     }
   }
+
+  // Upstream: https://github.com/uswds/uswds/pull/5267
+  button[aria-expanded='false'] span::after {
+    top: 50%;
+    transform: translateY(-50%);
+  }
 }
 
 // Navigation close button

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -4,249 +4,36 @@
 
 $header-height: 10;
 
-// Primary navigation
-// ---------------------------------
-
 .usa-nav__primary {
   @include at-media-max($theme-header-min-width) {
-    .usa-nav__primary-item,
-    .usa-nav__submenu-item {
-      > a,
-      > .usa-nav__link {
-        &:hover {
-          color: color('ink');
-        }
-      }
-
-      .usa-accordion__button {
-        background-position: right units(1) center;
-      }
-
-      .usa-current {
-        @include add-bar(0.5, 'secondary', 'left', 0, 0, 0);
-        font-weight: font-weight('bold');
-        background-color: color('primary-lighter');
-        color: color('ink');
-      }
-    }
-
-    .usa-nav__primary-item {
-      > a,
-      > .usa-nav__link {
-        @include u-padding-y(2);
-      }
-    }
-  }
-
-  @include at-media($theme-header-min-width) {
-    > .usa-nav__primary-item {
-      > a,
-      > .usa-nav__link {
-        @include u-padding-x(1.5);
-        font-weight: normal;
-        color: color('primary-dark');
-
-        &:hover {
-          @include add-bar(0.5, 'secondary', 'bottom', 0, 1.5, 0);
-          color: color('primary-dark');
-        }
-      }
-
-      .usa-accordion__button[aria-expanded='true'] {
-        @include remove-bar;
-        color: color('primary-dark');
-      }
-
-      .usa-current {
-        @include add-bar(0.5, 'secondary', 'bottom', 0, 1.5, 0);
-        font-weight: font-weight('bold');
-      }
-    }
-
-    button {
-      $button-vertical-offset: 53%; // XXX: Magic number
-
-      @include button-unstyled;
-      color: color(usa-nav.$nav-link-color);
-      font-weight: font-weight('normal');
-      line-height: line-height($theme-navigation-font-family, 2);
-      padding: units(1.5) units(2);
-      text-decoration: none;
-
-      @include at-media($theme-header-min-width) {
-        @include usa-nav.primary-nav-link;
-        font-size: font-size($theme-navigation-font-family, '2xs');
-        font-weight: font-weight('bold');
-      }
+    a:not(.usa-button) {
+      padding: units(2);
 
       &:hover {
-        color: color('primary');
-        background-color: color('base-lightest');
-        text-decoration: none;
-
-        @include at-media($theme-header-min-width) {
-          background-color: transparent;
-        }
-      }
-
-      &[aria-expanded='true'] {
-        @include add-background-svg('minus-alt');
-        background-position: right 0 center;
-        background-size: units(usa-nav.$nav-link-accordion-icon-size);
-
-        @include at-media($theme-header-min-width) {
-          @include add-background-svg('angle-arrow-up-primary');
-          @include add-knockout-font-smoothing;
-          background-size: units(usa-nav.$nav-link-arrow-icon-size);
-          background-color: color('primary-lighter');
-          background-position: right units(2) top $button-vertical-offset;
-          color: color('white');
-        }
+        background-color: color('primary-lightest');
       }
     }
-  }
-}
 
-// Secondary navigation
-// ---------------------------------
+    .usa-current {
+      color: color('primary-dark');
 
-.usa-nav__secondary {
-  @include at-media($theme-header-min-width) {
-    top: 0;
-    bottom: unset;
-    margin-top: 0;
-    transform: translateY(-100%);
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    height: units($header-height);
-  }
-}
-
-.usa-nav__secondary-links {
-  @include add-list-reset;
-  line-height: line-height($theme-navigation-font-family, 3);
-  margin-top: units(3);
-
-  @include at-media($theme-header-min-width) {
-    float: right;
-    line-height: line-height($theme-navigation-font-family, 1);
-    margin-bottom: units(0.5);
-    margin-top: 0;
-  }
-
-  .usa-nav__secondary-item {
-    @include at-media($theme-header-min-width) {
-      display: inline;
-      padding-left: units(0.5);
-
-      & + .usa-nav__secondary-item::before {
-        color: color('base-lighter');
-        content: '|';
-        padding-right: units(0.5);
+      &::after {
+        background-color: color('secondary');
       }
     }
   }
 
-  a {
-    color: color('ink');
-    display: inline-block;
-    font-size: font-size($theme-navigation-font-family, 'xs');
-    text-decoration: none;
-
-    &:hover {
-      color: color('primary');
-      text-decoration: underline;
-    }
-  }
-}
-
-// Navigation dropdowns
-// ---------------------------------
-
-.usa-nav__submenu {
-  @include at-media-max($theme-header-min-width) {
-    @include nav-sublist;
-  }
-
-  @include at-media($theme-header-min-width) {
-    @include add-list-reset;
-    background-color: color('primary-lighter');
-    width: units('card-lg');
-    padding: units(2);
-    position: absolute;
-    z-index: z-index(400);
-  }
-
-  &[aria-hidden='true'] {
-    display: none;
-  }
-
-  .usa-nav__submenu-item {
-    @include at-media($theme-header-min-width) {
-      & + * {
-        margin-top: units(1.5);
-      }
-
-      a {
+  > .usa-nav__primary-item {
+    > a {
+      @include at-media($theme-header-min-width) {
+        @include u-padding-x(1.5);
         color: color('primary-dark');
-        padding: 0;
-        line-height: line-height($theme-navigation-font-family, 3);
+        font-weight: font-weight('normal');
 
-        &:hover {
-          background-color: transparent;
-          color: color('primary-dark');
-          padding: 0;
-          text-decoration: underline;
+        &.usa-current {
+          font-weight: font-weight('bold');
         }
       }
     }
   }
-}
-
-.usa-nav__submenu-list {
-  @include unstyled-list;
-
-  .usa-nav__submenu-list-item {
-    margin: 0;
-    font-size: font-size($theme-navigation-font-family, '2xs');
-
-    a {
-      line-height: line-height($theme-navigation-font-family, 3);
-    }
-  }
-}
-
-// Navigation close button
-// ---------------------------------
-
-.usa-nav__close img {
-  width: units(1.5);
-}
-
-// Navigation menu
-// ---------------------------------
-
-.usa-logo__img {
-  @include at-media-max($theme-header-min-width) {
-    height: units(2);
-  }
-
-  @include at-media($theme-header-min-width) {
-    height: units(3);
-  }
-}
-
-.usa-logo__text {
-  @include at-media-max($theme-header-min-width) {
-    @include u-font-size($theme-header-font-family, 3);
-    padding-left: 17px;
-  }
-
-  @include at-media($theme-header-min-width) {
-    @include u-font-size($theme-header-font-family, 4);
-    padding-left: 27px;
-  }
-
-  color: color('secondary');
 }

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -44,7 +44,7 @@
   }
 
   // Upstream: https://github.com/uswds/uswds/pull/5267
-  button[aria-expanded='false'] span::after {
+  button[aria-expanded] span::after {
     top: 50%;
     transform: translateY(-50%);
   }

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -26,6 +26,10 @@
   }
 
   > .usa-nav__primary-item {
+    @include at-media($theme-header-min-width) {
+      font-size: 0.875rem;
+    }
+
     > a {
       @include at-media($theme-header-min-width) {
         @include u-padding-x(1.5);

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -19,6 +19,7 @@ $header-height: 10;
 
       &::after {
         background-color: color('secondary');
+        border-radius: 0;
       }
     }
   }

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -43,10 +43,16 @@
     }
   }
 
-  // Upstream: https://github.com/uswds/uswds/pull/5267
-  button[aria-expanded] span::after {
-    top: 50%;
-    transform: translateY(-50%);
+  button {
+    &:hover {
+      background-color: color('primary-lightest');
+    }
+
+    // Upstream: https://github.com/uswds/uswds/pull/5267
+    &[aria-expanded] span::after {
+      top: 50%;
+      transform: translateY(-50%);
+    }
   }
 }
 

--- a/src/scss/packages/_usa-nav.scss
+++ b/src/scss/packages/_usa-nav.scss
@@ -2,6 +2,9 @@
 @use './usa-nav/index' as usa-nav;
 @forward './usa-nav/index';
 
+// Primary navigation
+// ---------------------------------
+
 .usa-nav__primary {
   @include at-media-max($theme-header-min-width) {
     a:not(.usa-button) {
@@ -35,4 +38,11 @@
       }
     }
   }
+}
+
+// Navigation close button
+// ---------------------------------
+
+.usa-nav__close img {
+  width: units(1.5);
 }

--- a/src/scss/packages/_usa-section.scss
+++ b/src/scss/packages/_usa-section.scss
@@ -1,0 +1,17 @@
+@use 'uswds-core' as *;
+@forward './usa-section/index';
+
+.usa-section--dark {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    // As of USWDS 3.4.1, an inline code comment mentions making this configurable or defaulting to
+    // white, at which point it would no longer be necessary to override.
+    //
+    // See: https://github.com/uswds/uswds/blob/v3.4.1/packages/usa-section/src/styles/_usa-section.scss#L20-L29
+    color: color('white');
+  }
+}

--- a/src/scss/packages/_usa-sidenav.scss
+++ b/src/scss/packages/_usa-sidenav.scss
@@ -15,6 +15,7 @@
 
     &::after {
       background-color: color('secondary');
+      border-radius: 0;
     }
 
     &:hover {

--- a/src/scss/packages/_usa-sidenav.scss
+++ b/src/scss/packages/_usa-sidenav.scss
@@ -21,6 +21,10 @@
       color: color('primary-dark');
     }
   }
+
+  > .usa-sidenav__item > .usa-sidenav__sublist {
+    border-top: units(1px) solid color('base-lighter');
+  }
 }
 
 .usa-sidenav__sublist a:not(.usa-button) {

--- a/src/scss/packages/_usa-sidenav.scss
+++ b/src/scss/packages/_usa-sidenav.scss
@@ -7,28 +7,20 @@
 
     &:hover {
       background-color: color('primary-lightest');
-      color: unset;
     }
   }
 
   .usa-current {
-    color: $theme-color-primary-dark;
+    color: color('primary-dark');
 
-    @include add-bar($theme-sidenav-current-border-width, 'secondary', 'left', 0, 0, 0);
-
-    @include at-media('tablet') {
-      @include add-bar($theme-sidenav-current-border-width, 'secondary', 'left', 0, 0, 0);
+    &::after {
+      background-color: color('secondary');
     }
 
     &:hover {
-      color: $theme-color-primary-dark;
+      color: color('primary-dark');
     }
   }
-}
-
-.usa-sidenav--sticky {
-  position: sticky;
-  top: units(2);
 }
 
 .usa-sidenav__sublist a:not(.usa-button) {


### PR DESCRIPTION
This resolves a regression introduced as part of the changes in the 7.0.0 release where the "current" link would be shown with a blue underline instead of a red underline.

Example from https://design.login.gov/brand/ :

![image](https://user-images.githubusercontent.com/1779930/235514333-8e4ab54f-5f87-410a-ab01-854e3dfe4cd5.png)

Compare to https://login.gov/what-is-login/ :

![image](https://user-images.githubusercontent.com/1779930/235514424-b1759f8f-4dd7-4a44-8829-781183ffc11b.png)

After discussing with @nickttng , the changes here are a bit more of an extensive "reset" to USWDS stock styling, with minimal overrides to apply expected customizations:

- Remove bold text styling from links other than the current header navigation linik
- Change bar underline from blue ("primary" token) to red ("secondary" token)
- Reduce horizontal padding between header navigation items from 2rem (32px) to 1.5rem (24px)
- Reduce margins of logo
- Increase vertical padding of side navigation and mobile navigation items from 0.5rem (8px) to 1rem (16px)
- Change hover background color for side navigation and mobile navigation items from `base-lightest` (`#f0f0f0`) to `primary-lightest` (`#f2f9ff`)
- Remove borders between submenu links in side navigation and mobile navigation
- **Edit:** More revisions added based on feedback:
   - Remove border-radius from current link bar in side navigation and mobile navigation
   - Reduce size of mobile navigation "X" button
- **Edit 2:** More revisions based on further testing with downstream projects:
   - Remove border below header when followed by dark section (e.g. hero)
   - Increase font size of header navigation to from 13px to 14px

The idea of resetting to the USWDS is...

- Better understand divergence with USWDS
- Eliminate divergence where possible to reduce maintenance overhead and CSS size
- Align divergence with specific CSS selectors to reduce risk of future breakage

Open questions:

- Possible other revisions could include...
   - ~Changing side navigation and mobile navigation line to extend the full height of the list item~ **Edit:** Based on https://github.com/18F/identity-design-system/pull/352#pullrequestreview-1408054717, keeping height as-is, but removed border radius in 9f59575.
   - ~Reducing size of mobile navigation "X" button~ **Edit:** Added in e3a5d1f

To review:

- Header logo
- Header navigation
- Side navigation (impacted because it shares many of its stylings with mobile header navigation)

Component|Before|After
---|---|---
Header|![image](https://user-images.githubusercontent.com/1779930/235514333-8e4ab54f-5f87-410a-ab01-854e3dfe4cd5.png)|![image](https://user-images.githubusercontent.com/1779930/235515818-4d87439f-086f-48cc-a18d-471c57be27ac.png)
Side navigation|![image](https://user-images.githubusercontent.com/1779930/235516857-d383adda-25b4-411e-95fc-6aa4b46b4c69.png)|![image](https://user-images.githubusercontent.com/1779930/235687770-b477da0d-1a7f-4737-8eb7-d66fb508f6b2.png)
Mobile navigation|![design login gov_components_side-navigation_(iPhone XR)](https://user-images.githubusercontent.com/1779930/235517068-1e41f0e0-72d7-45b8-b9b0-96244001f3d5.png)|![localhost_4000_components_side-navigation_(iPhone XR)](https://user-images.githubusercontent.com/1779930/235687672-700dad71-09fc-456a-9298-3116a111f912.png)