### PR TITLE
Remove uswds-packages symlink

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,3 @@
 {
-  "extends": "@18f/identity-stylelint-config",
-  "ignoreFiles": "./src/scss/uswds-packages/**/*"
+  "extends": "@18f/identity-stylelint-config"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,7 +128,7 @@ gulp.task('build-sass', () =>
     .pipe(
       sass({
         outputStyle: isProduction ? 'compressed' : 'expanded',
-        includePaths: ['./src/scss/packages', './src/scss/uswds-packages'],
+        includePaths: ['./src/scss/packages', './node_modules/@uswds/uswds/packages'],
       }),
     )
     .pipe(

--- a/src/scss/uswds-packages
+++ b/src/scss/uswds-packages
@@ -1,1 +1,0 @@
-../../node_modules/@uswds/uswds/packages


### PR DESCRIPTION
**Why?**

- Simpler
- We don't need it, we can point directly to node_modules for the only place we use it now (Sass loadPaths)
- May have better cross-OS compatibility (i.e. Windows)