### PR TITLE
Fix Process List "Big" variant showing connected line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fix appearance of borders in segmented "Big" button groups. ([#359](https://github.com/18F/identity-design-system/pull/359))
 - Improve compilation time for default package by upwards of 50%. ([#356](https://github.com/18F/identity-design-system/pull/356))
 
+### Bug Fixes
+
+- Fix issue where the Process List "Big" variant would show with the connected line when not rendered in prose content.
+
 ## 7.0.1
 
 ### Bug Fixes

--- a/src/scss/packages/usa-process-list/src/_overrides.scss
+++ b/src/scss/packages/usa-process-list/src/_overrides.scss
@@ -51,7 +51,6 @@ $theme-process-list-counter-size-big: 3.125rem;
 
   .usa-process-list__item {
     padding-left: units(6);
-    border-left-width: units(1);
 
     &::before {
       margin-top: #{(
@@ -62,5 +61,9 @@ $theme-process-list-counter-size-big: 3.125rem;
       height: $theme-process-list-counter-size-big;
       font-size: units(3);
     }
+  }
+
+  &.usa-process-list--connected .usa-process-list__item {
+    border-left-width: units(1);
   }
 }


### PR DESCRIPTION
~Merges to (blocked by) #356~

Fixes an issue where Process List "Big" variant would show with the connected line when not rendered in prose content.

Issue can be seen here ("Big" should not show line): https://idp.dev.identitysandbox.gov/components/inspect/process_list/preview

Issue can't be seen here, since design system documentation is shown in `.usa-prose`: https://design.login.gov/components/process-list/#big

The underlying issue is a CSS specificity conflict, where the styles responsible for [unsetting the border width](https://github.com/18F/identity-design-system/blob/76d17e736e7c446476e22246ce1230bbd37745db/src/scss/packages/_usa-process-list.scss#L11-L13) were only strong enough to override [the previous border width styling](https://github.com/18F/identity-design-system/blob/76d17e736e7c446476e22246ce1230bbd37745db/src/scss/packages/_usa-process-list.scss#L55) when rendered inside `.usa-prose`, but not when rendered outside `.usa-prose`. The changes here make it so that the "Big" border is only applied to the connected process list.

**Testing Instructions:**

1. Go to https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-fix-process-list-big-connnected/process-list/#big
2. Observe the Big Process list shows without border
3. In DevTools console, enter `document.querySelector('.usa-prose').classList.remove('usa-prose')`
4. Observe the Big Process list still shows without border