### PR TITLE
Improve styling for segmented "big" button group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 
+- Fix appearance of borders in segmented "Big" button groups. ([#359](https://github.com/18F/identity-design-system/pull/359))
 - Improve compilation time for default package by upwards of 50%. ([#356](https://github.com/18F/identity-design-system/pull/356))
 
 ## 7.0.1

--- a/docs/_components/button-groups.md
+++ b/docs/_components/button-groups.md
@@ -1,0 +1,41 @@
+---
+title: Button Groups
+---
+
+{% include helpers/base-component.html component="button-group" %}
+
+## Segmented
+
+### Default
+
+{% capture example %}
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button</button>
+  </li>
+</ul>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
+### Big
+
+{% capture example %}
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
+  </li>
+</ul>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}

--- a/src/scss/packages/_usa-button-group.scss
+++ b/src/scss/packages/_usa-button-group.scss
@@ -1,0 +1,2 @@
+@forward 'usa-button-group/index';
+@forward 'usa-button-group/src/overrides';

--- a/src/scss/packages/usa-button-group/src/_overrides.scss
+++ b/src/scss/packages/usa-button-group/src/_overrides.scss
@@ -1,0 +1,21 @@
+@use 'uswds-core' as *;
+
+.usa-button-group__item {
+  &:first-child > .usa-button.usa-button--big {
+    margin-right: -1 * units($theme-button-stroke-width);
+  }
+
+  &:last-child > .usa-button.usa-button--big {
+    margin-left: -2 * units($theme-button-stroke-width);
+    width: calc(100% + #{units($theme-button-stroke-width) * 2});
+
+    @include at-media('mobile-lg') {
+      margin-left: -1 * units($theme-button-stroke-width);
+    }
+  }
+
+  &:where(:not(:first-child):not(:last-child)) > .usa-button.usa-button--big {
+    margin-right: -1 * units($theme-button-stroke-width);
+    margin-left: -1 * units($theme-button-stroke-width);
+  }
+}

--- a/src/scss/packages/usa-button-group/src/_styles.scss
+++ b/src/scss/packages/usa-button-group/src/_styles.scss
@@ -1,0 +1,2 @@
+@forward 'usa-button-group/src/styles/index';
+@forward './overrides';


### PR DESCRIPTION
~Merges to (blocked by) #356~

**Why?** LGDS styles default button stroke width as 1px, and has custom styles to override stroke width to 2px for big buttons. USWDS button group styles use the stroke width, but are not aware of our customizations to double the width for big buttons, so we need to manually override these styles.

In practice, this makes a small difference on the appearance of a borders buttons.

Before|After
---|---
![before](https://github.com/18F/identity-design-system/assets/1779930/b4ce04f9-c8ea-48e8-baab-cc9259a83406)|![after](https://github.com/18F/identity-design-system/assets/1779930/8a960ce4-8e13-4e25-a15f-8e1f5cd618b2)

Live preview URL: https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-button-groups-border/components/button-groups/

Related IdP usage: https://github.com/18F/identity-idp/pull/8542

LGDS big button customizations:

https://github.com/18F/identity-design-system/blob/1a488efdb6ff4ca1f0a05873440d60be93ec8c5e/src/scss/packages/_usa-button.scss#L4

Relevant USWDS styles: https://github.com/uswds/uswds/blob/8736f9305ee7547b7828fc1d625d83f458c6b44c/packages/usa-button-group/src/styles/_usa-button-group.scss#L80-L99