### PR TITLE
Add codeowners for frontend interest group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# About CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @18f/identity-frontend


### PR DESCRIPTION
Previously:

- [Engineering huddle discussion](https://docs.google.com/document/d/1g_V2vlT79tScBKIVw7M4UXf15TrG69iUrLHE0yE1GGI/edit#heading=h.8m6h50lb3tth)
- [Slack thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1686776030486199)

TBD: GitHub is flagging this as having a "syntax error" since the team needs to have write access to the repository, which may be an administrative logistical conundrum.