### PR TITLE
Add meta charset to documentation layout to fix visual regressions tests

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">


### PR DESCRIPTION
There have been some visual regression failures on recent pull requests related to content encoding (see https://github.com/18F/identity-design-system/pull/359#issuecomment-1585069144). Based on my understanding, it doesn't _seem_ like this tag should be necessary, as `utf-8` should already be the default for HTML5 documents. But it does appear to have a positive effect, where builds appear to be passing again (after 4 retries).