### PR TITLE
Automatically Fix Lint Issues in sass/scss Files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,6 +116,7 @@ gulp.task('lint-sass', async function (callback) {
   const { errored, output } = await stylelint.lint({
     files: [`${PROJECT_SASS_SRC}/**/*.scss`, `!${PROJECT_SASS_SRC}/uswds/**/*.scss`],
     formatter: 'string',
+    fix: true,
   });
 
   callback(errored ? new Error(output) : null);


### PR DESCRIPTION
**Description:**
While working on #369 I found that running `make lint` will lint scss files and output the errors, but not autofix what it finds. All the errors I had were fixable with the change in this PR.

This feels like a safe change to me, the worst that happens is some lint errors aren't resolved. It seems unlikely that there's something downstream that depends on these errors being outputted.

Note: I did consider adding the `fix` option to `lint-js` as well, but wasn't able to get it working immediately and decided that this was useful enough to put up anyway.

**To Test**
- `git checkout main`
- In an `scss` file of your choosing, add a bunch of newlines at the end to cause linting errors.
- `make lint`
- Note that you get lint error output, but the newlines are still there.
- `git checkout charley/fix-sass-lint-errors`
- `make lint`
- Note that you don't get lint errors and the newlines disappear.

**Before This PR**
To lint files:
- `make lint`
- Get the output in the terminal.
- Fix the output manually (or add the `fix: true` option to the gulpfile for `lint-sass` temporarily and rerun `make lint`).

**After this PR**
To lint files:
- `make lint`