### PR TITLE
Release Request: 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 ## Unreleased
+- 
 
+## 7.1.0
 ### Improvements
 
 - Fix appearance of borders in segmented "Big" button groups. ([#359](https://github.com/18F/identity-design-system/pull/359))
 - Improve compilation time for default package by upwards of 50%. ([#356](https://github.com/18F/identity-design-system/pull/356))
+- Upgrade Ruby and Puppeteer ([#367](https://github.com/18F/identity-design-system/pull/367) and [#364](https://github.com/18F/identity-design-system/pull/364))
+- LG-10522: Add Icon List Component ([#368](https://github.com/18F/identity-design-system/pull/368))
+- LG-10523: Add Image Example Component ([#369](https://github.com/18F/identity-design-system/pull/369))
 
 ### Bug Fixes
 
-- Fix issue where the Process List "Big" variant would show with the connected line when not rendered in prose content.
+- Fix issue where the Process List "Big" variant would show with the connected line when not rendered in prose content. ([#357](https://github.com/18F/identity-design-system/pull/357))
+- Add meta charset to documentation layout to fix visual regressions tests ([#361](https://github.com/18F/identity-design-system/pull/361))
 
 ## 7.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-## Unreleased
-- 
-
 ## 7.1.0
+
+### New Features
+
+- Add custom styling for the Icon List component. ([#368](https://github.com/18F/identity-design-system/pull/368))
+- Add new Image Example component. ([#369](https://github.com/18F/identity-design-system/pull/369))
+
 ### Improvements
 
 - Fix appearance of borders in segmented "Big" button groups. ([#359](https://github.com/18F/identity-design-system/pull/359))
 - Improve compilation time for default package by upwards of 50%. ([#356](https://github.com/18F/identity-design-system/pull/356))
-- Upgrade Ruby and Puppeteer ([#367](https://github.com/18F/identity-design-system/pull/367) and [#364](https://github.com/18F/identity-design-system/pull/364))
-- LG-10522: Add Icon List Component ([#368](https://github.com/18F/identity-design-system/pull/368))
-- LG-10523: Add Image Example Component ([#369](https://github.com/18F/identity-design-system/pull/369))
 
 ### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10861

❓ The Ask

@aduth Could you finish the release I started here? I don't yet have the correct npm access to run `npm publish`. I'm still working on that. `npm publish --dry-run` looks correct to me though.

💬 Changes

I'd like to release version `7.1.0` of the `identity-design-system`. This release contains all the work I can do (from [here](https://github.com/18F/identity-design-system/blob/a863995e7ffca82409645c15d34f0b979b6b1921/CONTRIBUTING.md#releases)) in that direction since I don't have the permissions to run `npm publish` in the 18f org on npm.

This PR contains:
- Changelog updates.
- A version number update from running `npm version minor`
- This PR is for an appropriately named release branch (7.1.0)