### PR TITLE
Disable Serif fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking Changes
 
+- Serif fonts are disabled by default. This should not have a noticeable impact in most cases, since the Serif fonts were already previously assigned to Public Sans (a Sans Serif font).
 - Update USWDS from 3.4.1 to 3.6.0
   - See release notes:
     - https://github.com/uswds/uswds/releases/tag/v3.5.0

--- a/src/scss/packages/_uswds-core.scss
+++ b/src/scss/packages/_uswds-core.scss
@@ -186,9 +186,12 @@ $site-palette: (
   $theme-root-font-size: 16px !default,
   // Font path
   $theme-font-path: if(variable-exists(font-path), $font-path, '../fonts') !default,
+  //  Font role
+  $theme-font-role-heading: 'sans',
+  $theme-font-role-alt: 'sans',
   // Font type
   $theme-font-type-sans: 'public-sans' !default,
-  $theme-font-type-serif: 'public-sans' !default,
+  $theme-font-type-serif: false !default,
   // Type scale
   $theme-type-scale-3xs: 'micro' !default,
   $theme-type-scale-2xs: 2 !default,


### PR DESCRIPTION
**Why?** We don't currently use Serif fonts. Previously, we overrode the Serif font face configuration to set Public Sans. Instead, this proposes to _disable_ the serif font, and reconfigure the heading to use the Sans "role". This should be more semantically accurate, and optimizes the output to prevent [serif-related font utilities](https://designsystem.digital.gov/utilities/font-size-and-family/) from being output.

There should be no visual impact expected from these changes.

Related: https://github.com/18F/identity-idp/pull/9290