### PR TITLE
Prepare 8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 8.0.0
 
 ### Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "7.1.0",
+      "version": "8.0.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
> ### Breaking Changes
> 
> - Serif fonts are disabled by default. This should not have a noticeable impact in most cases, since the Serif fonts were already previously assigned to Public Sans (a Sans Serif font).
> - Update USWDS from 3.4.1 to 3.6.1
>   - See release notes:
>     - https://github.com/uswds/uswds/releases/tag/v3.5.0
>     - https://github.com/uswds/uswds/releases/tag/v3.6.0
>     - https://github.com/uswds/uswds/releases/tag/v3.6.1
>   - Note "Breaking" changes in the above minor releases. Additionally, the `inputPrefixSuffix` JavaScript named export has been removed.