### PR TITLE
Mark font role variables as default

### DIFF
--- a/src/scss/packages/_uswds-core.scss
+++ b/src/scss/packages/_uswds-core.scss
@@ -187,8 +187,8 @@ $site-palette: (
   // Font path
   $theme-font-path: if(variable-exists(font-path), $font-path, '../fonts') !default,
   //  Font role
-  $theme-font-role-heading: 'sans',
-  $theme-font-role-alt: 'sans',
+  $theme-font-role-heading: 'sans' !default,
+  $theme-font-role-alt: 'sans' !default,
   // Font type
   $theme-font-type-sans: 'public-sans' !default,
   $theme-font-type-serif: false !default,


### PR DESCRIPTION
Small revision to #374 prior to releasing 8.0.0 version. I noticed in testing the release an error in `identity-idp` when trying to override this value. As you can see in all surrounding variables, we usually set `!default` flag to allow downstream projects to reconfigure any value from the design system, so that's introduced here for consistency to the variables configured in #374.