### PR TITLE
Fix issue with wrong accordion icon when hovering the expander

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 8.0.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ### Bug Fixes
 
-- Fix an issue where accordion icons appear smaller when hovering the expander button.
+- Fix an issue where accordion icons appear smaller when hovering the expander button. ([#379](https://github.com/18F/identity-design-system/pull/379))
 
 ## 8.0.0
 
 ### Breaking Changes
 
-- Serif fonts are disabled by default. This should not have a noticeable impact in most cases, since the Serif fonts were already previously assigned to Public Sans (a Sans Serif font).
-- Update USWDS from 3.4.1 to 3.6.1
+- Serif fonts are disabled by default. This should not have a noticeable impact in most cases, since the Serif fonts were already previously assigned to Public Sans (a Sans Serif font). ([#374](https://github.com/18F/identity-design-system/pull/374))
+- Update USWDS from 3.4.1 to 3.6.1 ([#362](https://github.com/18F/identity-design-system/pull/362), [#375](https://github.com/18F/identity-design-system/pull/375))
   - See release notes:
     - https://github.com/uswds/uswds/releases/tag/v3.5.0
     - https://github.com/uswds/uswds/releases/tag/v3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix an issue where accordion icons appear smaller when hovering the expander button.
+
 ## 8.0.0
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/packages/usa-accordion/src/_overrides.scss
+++ b/src/scss/packages/usa-accordion/src/_overrides.scss
@@ -4,11 +4,15 @@
   @include u-border($theme-accordion-border-width, $theme-accordion-border-color);
   @include u-radius('lg');
   @include u-text('normal');
-  @include add-background-svg('minus');
   background-color: color('transparent');
   background-size: units(2);
   color: color('primary');
   line-height: line-height($theme-body-font-family, $theme-body-line-height);
+
+  &,
+  &:hover {
+    @include add-background-svg('minus');
+  }
 
   &:hover {
     background-color: color('primary-lightest');
@@ -21,8 +25,12 @@
   }
 
   &[aria-expanded='false'] {
-    @include add-background-svg('plus');
     background-size: units(2);
+
+    &,
+    &:hover {
+      @include add-background-svg('plus');
+    }
   }
 }
 


### PR DESCRIPTION
Fixes an issue where the wrong icon appears when hovering the expanded or collapsed accordion button, due to specificity changes in USWDS.

Live preview: https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-fix-accordion-expander/accordions/

State|Before|After
---|---|---
Expanded|![image](https://github.com/18F/identity-design-system/assets/1779930/a043bca6-d344-4af5-b2f6-c79b062e8b34)|![image](https://github.com/18F/identity-design-system/assets/1779930/b7cd78be-fdef-4dd5-87c4-235c21bfb188)
Collapsed|![image](https://github.com/18F/identity-design-system/assets/1779930/466b415e-e8ce-408f-8d34-f3a484063807)|![image](https://github.com/18F/identity-design-system/assets/1779930/3d2b0f73-2445-41b3-889d-5c8f568ebebb)

Unhovered, for reference:

![image](https://github.com/18F/identity-design-system/assets/1779930/c0e891d1-0a23-4c88-ad6e-814558dd076b)

