### PR TITLE
Add Summary Box component

### DIFF
--- a/docs/_components/summary-box.md
+++ b/docs/_components/summary-box.md
@@ -1,0 +1,48 @@
+---
+title: Summary Box
+lead: >
+  A summary box highlights key information from a longer page or displays next steps.
+---
+
+{% include helpers/base-component.html component="summary-box" %}
+
+## Default
+
+{% capture example %}
+<div
+  class="usa-summary-box"
+  role="region"
+  aria-labelledby="summary-box-key-information"
+>
+  <div class="usa-summary-box__body">
+    <h3 class="usa-summary-box__heading" id="summary-box-key-information">
+      Key information
+    </h3>
+    <div class="usa-summary-box__text">
+      <ul class="usa-list">
+        <li>
+          If you are under a winter storm warning,
+          <a class="usa-summary-box__link" href="">find shelter</a> right away.
+        </li>
+        <li>
+          Sign up for
+          <a class="usa-summary-box__link" href=""
+            >your community’s warning system</a
+          >.
+        </li>
+        <li>
+          Learn the signs of, and basic treatments for,
+          <a class="usa-summary-box__link" href="">frostbite</a> and
+          <a class="usa-summary-box__link" href="">hypothermia</a>.
+        </li>
+        <li>
+          Gather emergency supplies for your
+          <a class="usa-summary-box__link" href="">home</a> and your
+          <a class="usa-summary-box__link" href="">car</a>.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}

--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -3,8 +3,11 @@
   {% assign stylesheet = include.component | prepend: 'usa-' %}
 {% endunless %}
 {% assign uswds_url = include.component | append: '/' | prepend: 'https://designsystem.digital.gov/components/' %}
-{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-design-system/blob/main/src/scss/packages/_' %}
+{% assign sass_project_path = stylesheet | append: '.scss' | prepend: 'src/scss/packages/_' %}
 
 [View USWDS component for guidance]({{ uswds_url }}){: .usa-link--external}
 
-[View Login.gov SCSS on GitHub]({{ sass_url }}){: .usa-link--external}
+{% if_file_exists sass_project_path %}
+  {% assign sass_url = sass_project_path | prepend: 'https://github.com/18F/identity-design-system/blob/main/' %}
+  [View Login.gov SCSS on GitHub]({{ sass_url }}){: .usa-link--external}
+{% endif_file_exists %}

--- a/docs/_plugins/file_exists.rb
+++ b/docs/_plugins/file_exists.rb
@@ -1,0 +1,14 @@
+module Jekyll
+  class IfFileExistsTagBlock < Liquid::Block
+    def render(context)
+      file = context[@markup.strip]
+      if File.exist?(file)
+        super
+      else
+        ''
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('if_file_exists', Jekyll::IfFileExistsTagBlock)


### PR DESCRIPTION
Incorporates the Summary Box component into the Login.gov Design System.

**Draft:** Currently draft while it's determined which customizations (if any) are expected.

Live preview URL: https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-summary-box/summary-box/