### PR TITLE
Add variant support for danger outline buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New Features
+
+- Add variant support for danger outline buttons.
+
 ### Dependencies
 
 - Update USWDS from v3.6.1 to v3.7.0. ([#381](https://github.com/18F/identity-style-guide/pull/381))

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -57,6 +57,20 @@ subnav:
   <button class="usa-button usa-button--danger" disabled>Disabled</button>
 </div>
 
+### Danger Outline
+
+```html
+<button class="usa-button usa-button--danger usa-button--outline">
+```
+
+<div>
+  <button class="usa-button usa-button--danger usa-button--outline">Default</button>
+  <button class="usa-button usa-button--danger usa-button--outline usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--danger usa-button--outline usa-button--active">Active</button>
+  <button class="usa-button usa-button--danger usa-button--outline usa-focus">Focus</button>
+  <button class="usa-button usa-button--danger usa-button--outline" disabled>Disabled</button>
+</div>
+
 ### Unstyled
 
 ```html
@@ -113,6 +127,20 @@ subnav:
   <button class="usa-button usa-button--big usa-button--danger usa-button--active">Active</button>
   <button class="usa-button usa-button--big usa-button--danger usa-focus">Focus</button>
   <button class="usa-button usa-button--big usa-button--danger" disabled>Disabled</button>
+</div>
+
+### Danger Outline
+
+```html
+<button class="usa-button usa-button--big usa-button--danger usa-button--outline">
+```
+
+<div>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--outline">Default</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--outline usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--outline usa-button--active">Active</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--outline usa-focus">Focus</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--outline" disabled>Disabled</button>
 </div>
 
 ### Unstyled

--- a/src/scss/packages/usa-button/src/_overrides.scss
+++ b/src/scss/packages/usa-button/src/_overrides.scss
@@ -94,6 +94,27 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
   &.usa-button--active {
     background-color: color('secondary-darkest');
   }
+
+  &.usa-button--outline:not(:disabled, .usa-button--disabled) {
+    background-color: color('white');
+    box-shadow: inset 0 0 0 $theme-button-stroke-width color('secondary');
+    color: color('secondary');
+
+    &.usa-button--big {
+      box-shadow: $button-stroke-big color('secondary');
+    }
+
+    &:hover,
+    &.usa-button--hover {
+      background-color: color('secondary-lightest');
+    }
+
+    &:active,
+    &.usa-button--active {
+      background-color: color('secondary-lighter');
+      color: color('secondary-dark');
+    }
+  }
 }
 
 .usa-button--inverse {


### PR DESCRIPTION
Adds styles for combination of "danger" and "outline" button variants.

Live preview: https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-danger-outline-button/buttons/#danger-outline

**Screenshots:**

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/d0aa8c4f-e3f4-43b8-a31b-fdbd47ac890e)|![image](https://github.com/18F/identity-design-system/assets/1779930/0f5a343e-8637-43b0-9c2a-0a549b061db1)
