### PR TITLE
Fix Makefile start command parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ ifdef SITE_PREFIX
 	OUTPUT_DIR = ./_site
 endif
 
-start: start-docs start-assets
+start:
+	$(MAKE) -j2 start-docs start-assets
 
 start-docs:
 	bundle exec jekyll serve --watch


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a regression of #385 (6da543a39c0eb215f901c3b76005f32f62a11693) which caused `npm start` to no longer compile JavaScript and Sass assets automatically due to the expectation that Makefile targets would be run in parallel. It does so by restoring parallelism in a subprocess for the `start` target.

## 📜 Testing Plan

1. Run `npm start`
2. Observe in the output: `npm run watch:docs`