### PR TITLE
Hide broken link for uncustomized components

### DIFF
--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -3,8 +3,11 @@
   {% assign stylesheet = include.component | prepend: 'usa-' %}
 {% endunless %}
 {% assign uswds_url = include.component | append: '/' | prepend: 'https://designsystem.digital.gov/components/' %}
-{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-design-system/blob/main/src/scss/packages/_' %}
+{% assign sass_project_path = stylesheet | append: '.scss' | prepend: 'src/scss/packages/_' %}
 
 [View USWDS component for guidance]({{ uswds_url }}){: .usa-link--external}
 
-[View Login.gov SCSS on GitHub]({{ sass_url }}){: .usa-link--external}
+{% if_file_exists sass_project_path %}
+  {% assign sass_url = sass_project_path | prepend: 'https://github.com/18F/identity-design-system/blob/main/' %}
+  [View Login.gov SCSS on GitHub]({{ sass_url }}){: .usa-link--external}
+{% endif_file_exists %}

--- a/docs/_plugins/file_exists.rb
+++ b/docs/_plugins/file_exists.rb
@@ -1,0 +1,14 @@
+module Jekyll
+  class IfFileExistsTagBlock < Liquid::Block
+    def render(context)
+      file = context[@markup.strip]
+      if File.exist?(file)
+        super
+      else
+        ''
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('if_file_exists', Jekyll::IfFileExistsTagBlock)


### PR DESCRIPTION
## 🛠 Summary of changes

Avoids showing a link to "View Login.gov SCSS on GitHub" for a component documentation page if there is no custom Sass styling for that component.

## 📜 Testing Plan

1. Go to https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/preview/18f/identity-design-system/aduth-docs-overrides-404/icon-list/
2. Observe there is no link for "View Login.gov SCSS on GitHub", since we don't customize the styles for this component
3. Compare to current main: https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/site/18f/identity-design-system/icon-list/