### PR TITLE
Remove unnecessary load-path from usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The only requirements for Sass compilation are:
 If you're using `@18f/identity-build-sass`, the following command will compile a CSS file to `build/styles.css`:
 
 ```
-npx build-sass path/to/styles.css.scss --out-dir=build --load-path=node_modules/@18f/identity-design-system/packages
+npx build-sass path/to/styles.css.scss --out-dir=build
 ```
 
 ### JavaScript


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `README.md` usage example to simplify the Sass build command to avoid an unnecessary options flag.

`@18f/identity-build-sass` will automatically add the load path as of `@18f/identity-build-sass@1.2.0` (https://github.com/18F/identity-idp/pull/8346):

From [CHANGELOG.md](https://github.com/18F/identity-idp/blob/main/app/javascript/packages/build-sass/CHANGELOG.md#120):

>If `@18f/identity-design-system` is installed, `node_modules/@18f/identity-design-system/packages` is added as a load path.

## 📜 Testing Plan

Follow the usage instructions and verify there are no errors when running the given command.