### PR TITLE
Prepare 8.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 8.1.0
 
 ### New Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "The global style of Login.gov",
   "main": "./build/esm/index.js",
   "type": "module",


### PR DESCRIPTION
>## 8.1.0
>
>### New Features
>
>- Add variant support for danger outline buttons. ([#383](https://github.com/18F/identity-style-guide/pull/383))
>
>### Bug Fixes
>- Improve consistency with USWDS disabled buttons styles. ([#383](https://github.com/18F/identity-style-guide/pull/383))
>   - [USWDS v3.5.0](https://github.com/uswds/uswds/releases/tag/v3.5.0) removed `.usa-button--disabled` styling in favor of `[aria-disabled="true"]`. This wasn't documented as a breaking change, and it's expected the any `.usa-button--disabled` usage would not be stylized correctly since those changes. You should replace any usage of `usa-button--disabled` with either the `[disabled]` or `[aria-disabled="true"]` attributes.
>
>### Internal
>
>- The package is now distributed using native ES Modules as the default output. This should not impact downstream CommonJS projects, as a CommonJS distributable is still included for now. ([#395](https://github.com/18F/identity-design-system/pull/395))