### PR TITLE
Use fully-qualified path for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/381))
   - Support was indirectly dropped in [v7.0.0](https://github.com/18F/identity-design-system/releases/tag/v7.0.0) via the upgrade to USWDS [v3.0.0](https://designsystem.digital.gov/about/releases/#version-uswds-300), which similarly ended explicit support for Internet Explorer. This package had continued to include Internet Explorer in its [Browserslist](https://browsersl.ist/) configuration, but this has now been removed.
 
+### Bug Fixes
+
+- Fix strict ES Module import errors due to lack of fully-qualified file path.
+
 ### Internal
 
 - Replace code compiler Babel with ESBuild. ([#387](https://github.com/18F/identity-style-guide/pull/381))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/381))
   - Support was indirectly dropped in [v7.0.0](https://github.com/18F/identity-design-system/releases/tag/v7.0.0) via the upgrade to USWDS [v3.0.0](https://designsystem.digital.gov/about/releases/#version-uswds-300), which similarly ended explicit support for Internet Explorer. This package had continued to include Internet Explorer in its [Browserslist](https://browsersl.ist/) configuration, but this has now been removed.
 
+## 8.1.1
+
 ### Bug Fixes
 
 - Fix strict ES Module import errors due to lack of fully-qualified file path.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,1 +1,1 @@
-export * from './components';
+export * from './components/index.js';


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a regression in #395 where using ES Modules requires imports to reference the full path of any file.

See: https://nodejs.org/api/esm.html#mandatory-file-extensions

Error after upgrading to `8.1.0` in `identity-site`:

```
ERROR in ./node_modules/@18f/identity-design-system/build/esm/index.js 1:0-29
Module not found: Error: Can't resolve './components' in '/Code/identity-site/node_modules/@18f/identity-design-system/build/esm'
Did you mean 'index.js'?
BREAKING CHANGE: The request './components' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

This will be planned to be released as a 8.1.1 patch release, cherry-picked onto a branch from the v8.1.0 tag.

## 📜 Testing Plan

While I'm pretty sure I had tried to do this already, you could try updating `identity-site` `package.json` to reference its dependency as a file path, run `npm install`, and verify that `npm run build:js` completes successfully

```
"@18f/identity-design-system": "file:../identity-design-system",
```