### PR TITLE
Fix CommonJS import compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,22 @@
 - Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/381))
   - Support was indirectly dropped in [v7.0.0](https://github.com/18F/identity-design-system/releases/tag/v7.0.0) via the upgrade to USWDS [v3.0.0](https://designsystem.digital.gov/about/releases/#version-uswds-300), which similarly ended explicit support for Internet Explorer. This package had continued to include Internet Explorer in its [Browserslist](https://browsersl.ist/) configuration, but this has now been removed.
 
-## 8.1.1
-
-### Bug Fixes
-
-- Fix strict ES Module import errors due to lack of fully-qualified file path.
-
 ### Internal
 
 - Replace code compiler Babel with ESBuild. ([#387](https://github.com/18F/identity-style-guide/pull/381))
   - This is not expected to have a downstream impact, but there may be subtle differences in the compiled code due to this change.
+
+## 8.1.2
+
+### Bug Fixes
+
+- Fix issue with dual export backwards-compatibility resulting in errors loading in CommonJS projects. ([#401](https://github.com/18F/identity-design-system/pull/401))
+
+## 8.1.1
+
+### Bug Fixes
+
+- Fix strict ES Module import errors due to lack of fully-qualified file path. ([#400](https://github.com/18F/identity-design-system/pull/400))
 
 ## 8.1.0
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build:docs": "run-p build:docs:*",
     "build:pkg:css": "npm run build:css",
     "build:pkg:cjs": "esbuild `find src/js -name '*.js'` --outdir=build/cjs --format=cjs --target=`./scripts/esbuild-targets.mjs`",
+    "postbuild:pkg:cjs": "echo '{\"type\":\"commonjs\"}' > build/cjs/package.json",
     "build:pkg:esm": "esbuild `find src/js -name '*.js'` --outdir=build/esm --format=esm --target=`./scripts/esbuild-targets.mjs`",
     "build:pkg": "run-p build:pkg:*",
     "lint:js": "eslint src/js test",


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes another regression of #395, where downstream projects can resolve the CommonJS built output, but would treat its code as ES Modules, since the project's top-level `package.json` includes `"type": "module"`. It's unclear why this wouldn't have been an issue prior to #395.

Example failure: https://github.com/18F/identity-idp/pull/9992

Error:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Code/identity-idp/app/javascript/packages/clipboard-button/clipboard-button-element.spec.ts
```

I'm  not 100% about the solution here since typically a package would only contain a single, root-level `package.json`. However, I've tested to confirm that it works, and have seen the idea referenced in a few places:

- https://2ality.com/2019/10/hybrid-npm-packages.html#option-3%3A-bare-import-esm%2C-deep-import-commonjs-with-backward-compatibility
- https://github.com/nodejs/node/issues/34515#issuecomment-664209714

The alternatives could be to use either Babel CLI's (prior to 9.0.0) `--out-file-extension .cjs` or ESBuild's (after 9.0.0) `--out-extension:.js=.cjs` to control the file extension output for CommonJS. However, there's not an easy solution to change [the source code's path references](https://github.com/18F/identity-design-system/blob/main/src/js/index.js) based on the built output type, aside from using a third-party plugin like [`babel-plugin-replace-import-extension`](https://www.npmjs.com/package/babel-plugin-replace-import-extension).

## 📜 Testing Plan

This is easiest to verify via the pull request mentioned above: https://github.com/18F/identity-idp/pull/9992

1. `cd identity-idp`
2. `git checkout dependabot/npm_and_yarn/18f/identity-design-system-8.1.1`
3. `yarn install`
4. `yarn mocha app/javascript/packages/clipboard-button/clipboard-button-element.spec.ts`
5. Observe the error mentioned above
6. Apply fix manually: `echo '{"type":"commonjs"}' > node_modules/@18f/identity-design-system/build/cjs/package.json`
7. Re-run `yarn mocha app/javascript/packages/clipboard-button/clipboard-button-element.spec.ts`
8. Observe test passes successfully