### PR TITLE
Use Incognito in visual regressions to avoid visited link styling

### DIFF
--- a/docs/_components/prose.md
+++ b/docs/_components/prose.md
@@ -45,9 +45,7 @@ This is an unordered list
 
 This is a [text link](?{{ site.time | date: "%s%N" }}) on a light background, using the LDGS primary-blue color
 
-This is a <a href="{{ site.baseurl }}" class="usa-link usa-link--visited">visited text link</a>, using the USWDS setting (#54278F)
-
-This is a link that goes to an <a href="{{ site.baseurl }}" class="usa-link usa-link--external">external website</a>.
+This is a link that goes to an <a href="?{{ site.time | date: '%s%N' }}" class="usa-link usa-link--external">external website</a>.
 
 <div class="usa-section--dark padding-1">
   This is a <a href="?{{ site.time | date: '%s%N' }}" class="usa-link">text link</a> on a dark background

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -89,14 +89,18 @@ describe('screenshot visual regression', { skip, concurrency: true }, () => {
   /** @type {import('puppeteer').Browser} */
   let browser;
 
+  /** @type {import('puppeteer').BrowserContext} */
+  let browserContext;
+
   before(async () => {
     esbuildContext = await esbuild.context({});
     port = (await esbuildContext.serve({ servedir: 'dist' })).port;
     browser = await puppeteer.launch({ headless: 'new' });
+    browserContext = await browser.createIncognitoBrowserContext();
   });
 
   after(async () => {
-    await Promise.all([browser.close(), esbuildContext.dispose()]);
+    await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);
   });
 
   it('has pages to test', () => {
@@ -106,7 +110,7 @@ describe('screenshot visual regression', { skip, concurrency: true }, () => {
   paths.forEach((path) => {
     test(path, async () => {
       const localURL = `http://localhost:${port}`;
-      const page = await browser.newPage();
+      const page = await browserContext.newPage();
       const local = await getScreenshot(page, localURL + path);
       const remote = await getScreenshot(page, REMOTE_HOST + path);
       const localPNG = PNG.sync.read(local);


### PR DESCRIPTION
## 🛠 Summary of changes

Attempts to fix some test flakiness in visual regression specs, where links may sometimes be "visited" and appear in a purple color depending on test parallelism, since pages are now run concurrently across multiple tabs as of #389.

The solution is to use a Chrome Incognito (private browsing) context, where history will not be remembered. In my brief testing of a live Incognito tab, links will never show with visited styling.

## 📜 Testing Plan

Build should pass.

Test locally:

```
ONLY_VISUAL_REGRESSION_TEST=1 make test
```