### PR TITLE
Run visual regression testing as self-contained without external hosting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - checkout
       - bundle-npm-install
+      - attach_workspace:
+          at: tmp/screenshot/branches
       - run:
           name: Run visual regression test
           command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,10 @@ jobs:
           name: Run visual regression test
           command: npm test
       - store_artifacts:
-          path: tmp/results
+          path: tmp/screenshot/diff
           destination: results
       - store_test_results:
-          path: tmp/results
+          path: tmp/screenshot/diff
 
 ignore_main: &ignore_main
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
       - persist_to_workspace:
           root: tmp/screenshot/branches
           paths:
-            - *
+            - '*'
 
 jobs:
   lints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,10 @@ jobs:
   snapshot-main:
     executor: ruby_browsers
     steps:
+      - checkout
       - run:
           name: Checkout main
-          command: git clone -b main << pipeline.trigger_parameters.github_app.repo_url >>
+          command: git checkout main
       - bundle-npm-install
       - build
       - snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
     steps:
       - run:
           name: Build assets and site
-          command: npm run build
+          command: make build
   snapshot:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ commands:
       - run:
           name: Build assets and site
           command: npm run build
+  snapshot:
+    steps:
+      - run:
+          name: Generate snapshots
+          command: scripts/snapshot.js
 
 jobs:
   lints:
@@ -65,6 +70,22 @@ jobs:
       - run:
           name: Run integration tests
           command: npm test
+  snapshot-main:
+    executor: ruby_browsers
+    steps:
+      - run:
+          name: Checkout main
+          command: git checkout main
+      - bundle-npm-install
+      - build
+      - snapshot
+  snapshot-branch:
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - bundle-npm-install
+      - build
+      - snapshot
   visual-regression:
     executor: ruby_browsers
     environment:
@@ -87,4 +108,14 @@ workflows:
     jobs:
       - lints
       - integration
-      - visual-regression
+  visual_regression:
+    filters:
+      branches:
+        ignore: main
+    jobs:
+      - snapshot-main
+      - snapshot-branch
+      - visual-regression:
+        requires:
+          - snapshot-main
+          - snapshot-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,12 @@ jobs:
       - store_test_results:
           path: tmp/results
 
+ignore_main:
+  filters:
+    branches:
+      ignore:
+        - main
+
 workflows:
   version: 2
   test:
@@ -112,14 +118,13 @@ workflows:
       - lints
       - integration
   visual_regression:
-    filters:
-      branches:
-        ignore:
-          - main
     jobs:
-      - snapshot-main
-      - snapshot-branch
+      - snapshot-main:
+          <<: *ignore_main
+      - snapshot-branch:
+          <<: *ignore_main
       - visual-regression:
+          <<: *ignore_main
           requires:
             - snapshot-main
             - snapshot-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - run:
           name: Checkout main
-          command: git clone -b main "$CIRCLE_REPOSITORY_URL"
+          command: git clone -b main << pipeline.trigger_parameters.github_app.repo_url >>
       - bundle-npm-install
       - build
       - snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - run:
           name: Checkout main
-          command: git checkout main
+          command: git clone -b main "$CIRCLE_REPOSITORY_URL"
       - bundle-npm-install
       - build
       - snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ workflows:
   visual_regression:
     filters:
       branches:
-        ignore: main
+        ignore:
+          - main
     jobs:
       - snapshot-main
       - snapshot-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - checkout
       - run:
           name: Checkout main
-          command: git checkout main
+          command: git checkout main -- docs src package.json package-lock.json Gemfile Gemfile.lock
       - bundle-npm-install
       - build
       - snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - store_test_results:
           path: tmp/results
 
-ignore_main:
+ignore_main: &ignore_main
   filters:
     branches:
       ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ commands:
       - run:
           name: Generate snapshots
           command: scripts/snapshot.js
+      - persist_to_workspace:
+          paths:
+            - tmp/screenshot/branches
 
 jobs:
   lints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,10 @@ jobs:
       - checkout
       - run:
           name: Checkout main
-          command: git checkout main -- docs src package.json package-lock.json Gemfile Gemfile.lock
+          command: git checkout main
+      - run:
+          name: Restore snapshot script
+          command: git checkout "$CIRCLE_BRANCH" -- scripts/snapshot.js
       - bundle-npm-install
       - build
       - snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,6 @@ workflows:
       - snapshot-main
       - snapshot-branch
       - visual-regression:
-        requires:
-          - snapshot-main
-          - snapshot-branch
+          requires:
+            - snapshot-main
+            - snapshot-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,9 @@ commands:
           name: Generate snapshots
           command: scripts/snapshot.js
       - persist_to_workspace:
+          root: tmp/screenshot/branches
           paths:
-            - tmp/screenshot/branches
+            - *
 
 jobs:
   lints:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "extends": "plugin:@18f/eslint-plugin-identity/recommended",
   "plugins": ["@18f/eslint-plugin-identity"],
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
   "env": {
     "node": true,
     "browser": true

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,11 @@ build-images:
 	cp -r node_modules/@uswds/uswds/dist/img $(OUTPUT_DIR)/assets
 	cp -r src/img $(OUTPUT_DIR)/assets
 
-test: build
+test:
 ifdef ONLY_VISUAL_REGRESSION_TEST
 	node --test test/screenshot.test.js
 else
+	make build
 	node --test test/
 endif
 

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -6,8 +6,6 @@ lead: >
 
 {% include helpers/base-component.html component="accordion" %}
 
-Before using an accordion, consider if their use would hinder usability. If there is not enough content to warrant condensing or if visitors need to see most or all of the information on a page, use well-formatted text instead.
-
 {% capture example %}
 <div class="usa-accordion usa-accordion--bordered" data-test="accordion">
   <!-- Use the accurate heading level to maintain the document outline -->

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -6,6 +6,8 @@ lead: >
 
 {% include helpers/base-component.html component="accordion" %}
 
+Before using an accordion, consider if their use would hinder usability. If there is not enough content to warrant condensing or if visitors need to see most or all of the information on a page, use well-formatted text instead.
+
 {% capture example %}
 <div class="usa-accordion usa-accordion--bordered" data-test="accordion">
   <!-- Use the accurate heading level to maintain the document outline -->

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { promisify } from 'node:util';
+import { exec as _exec } from 'node:child_process';
+import { dirname, relative, join, extname, basename } from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import glob from 'fast-glob';
+import esbuild from 'esbuild';
+import puppeteer from 'puppeteer';
+
+const exec = promisify(_exec);
+
+const paths = (await glob('dist/*/index.html')).map((path) => dirname(relative('dist', path)));
+const branch = (await exec('git branch --show-current')).stdout.trim();
+
+/**
+ * @param {import('puppeteer').Page} page
+ * @param {string} url
+ */
+async function getScreenshot(page, url) {
+  await page.goto(url, { waitUntil: 'networkidle0' });
+  return page.screenshot({ fullPage: true, optimizeForSpeed: true });
+}
+
+const esbuildContext = await esbuild.context({});
+const { port } = await esbuildContext.serve({ servedir: 'dist' });
+const browser = await puppeteer.launch({ headless: 'new' });
+const browserContext = await browser.createIncognitoBrowserContext();
+const localURL = `http://localhost:${port}/`;
+const outputDirectory = join('tmp/screenshot/branches', branch);
+
+await mkdir(outputDirectory, { recursive: true });
+await Promise.all(
+  paths.map(async (path) => {
+    const page = await browserContext.newPage();
+    const screenshot = await getScreenshot(page, localURL + path);
+    const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
+    await writeFile(filename, screenshot);
+  }),
+);
+await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -35,6 +35,7 @@ await Promise.all(
     const page = await browserContext.newPage();
     const screenshot = await getScreenshot(page, localURL + path);
     const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
+    process.stdout.write(`Writing ${filename}...\n`);
     await writeFile(filename, screenshot);
   }),
 );

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -1,59 +1,24 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-param-reassign */
 
-import { describe, before, after, it, test } from 'node:test';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { describe, it, test } from 'node:test';
+import { promisify } from 'node:util';
+import { exec as _exec } from 'node:child_process';
+import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
 import assert from 'node:assert';
-import { join, dirname, resolve, relative } from 'node:path';
-import * as esbuild from 'esbuild';
-import glob from 'fast-glob';
-import puppeteer from 'puppeteer';
+import { join } from 'node:path';
 import { PNG } from 'pngjs';
 import match from 'pixelmatch';
 
-const paths = glob.sync('dist/*/index.html').map((path) => `/${dirname(relative('dist', path))}/`);
+const exec = promisify(_exec);
 
-const REMOTE_HOST =
-  'https://federalist-340d8801-aa16-4df5-ad22-b1e3e731098e.sites.pages.cloud.gov/site/18f/identity-design-system';
-const DIFF_DIRECTORY = resolve('tmp/results/screenshot-diff');
+const branch = (await exec('git branch --show-current')).stdout.trim();
 
-async function stubAnimations(page) {
-  await page.evaluate(() => {
-    const isGif = (img) => img.src.endsWith('.gif');
-    function stubGif(img) {
-      // Disable reason: Self-assignment for attribute reflection.
-      // See: https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes
-      /* eslint-disable no-self-assign */
-      img.width = img.width;
-      img.height = img.height;
-      /* eslint-enable no-self-assign */
-      img.src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-      img.removeAttribute('srcset');
-    }
+const DIFF_DIRECTORY = 'tmp/screenshot/diff';
+const SNAPSHOT_DIRECTORY = 'tmp/screenshot/branches';
+const MAIN_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, 'main');
+const BRANCH_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, branch);
 
-    [...document.querySelectorAll('img')].filter(isGif).forEach(stubGif);
-  });
-}
-
-async function toggleHiddenContent(page) {
-  await page.$$eval('.usa-accordion__container', (containers) =>
-    containers.forEach((container) => container.removeAttribute('hidden')),
-  );
-}
-
-async function getScreenshot(page, url) {
-  await page.goto(url, { waitUntil: 'networkidle0' });
-  await Promise.all([stubAnimations(page), toggleHiddenContent(page)]);
-  return page.screenshot({ fullPage: true, optimizeForSpeed: true });
-}
-
-function getDiffOutputBaseFileName(pathname) {
-  let normalizedPathname = pathname;
-  normalizedPathname = normalizedPathname.replace(/^\/|\/$/g, '');
-  normalizedPathname = normalizedPathname.replace(/\W/g, '_');
-  normalizedPathname = normalizedPathname || 'home';
-
-  return join(DIFF_DIRECTORY, normalizedPathname);
-}
+const paths = await readdir(MAIN_SNAPSHOTS_DIRECTORY);
 
 function fillImageToSize(image, width, height) {
   if (image.width === width && image.height === height) {
@@ -80,41 +45,14 @@ function fillImageToSize(image, width, height) {
 const skip = !!process.env.SKIP_VISUAL_REGRESSION_TEST;
 
 describe('screenshot visual regression', { skip, concurrency: true }, () => {
-  /** @type {import('esbuild').BuildContext} */
-  let esbuildContext;
-
-  /** @type {number} */
-  let port;
-
-  /** @type {import('puppeteer').Browser} */
-  let browser;
-
-  /** @type {import('puppeteer').BrowserContext} */
-  let browserContext;
-
-  before(async () => {
-    esbuildContext = await esbuild.context({});
-    port = (await esbuildContext.serve({ servedir: 'dist' })).port;
-    browser = await puppeteer.launch({ headless: 'new' });
-    browserContext = await browser.createIncognitoBrowserContext();
-  });
-
-  after(async () => {
-    await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);
-  });
-
   it('has pages to test', () => {
     assert(paths.length);
   });
 
   paths.forEach((path) => {
     test(path, async () => {
-      const localURL = `http://localhost:${port}`;
-      const page = await browserContext.newPage();
-      const local = await getScreenshot(page, localURL + path);
-      const remote = await getScreenshot(page, REMOTE_HOST + path);
-      const localPNG = PNG.sync.read(local);
-      const remotePNG = PNG.sync.read(remote);
+      const localPNG = PNG.sync.read(await readFile(join(BRANCH_SNAPSHOTS_DIRECTORY, path)));
+      const remotePNG = PNG.sync.read(await readFile(join(MAIN_SNAPSHOTS_DIRECTORY, path)));
       const width = Math.max(localPNG.width, remotePNG.width);
       const height = Math.max(localPNG.height, remotePNG.height);
       const resizedLocalPNG = fillImageToSize(localPNG, width, height);
@@ -124,12 +62,11 @@ describe('screenshot visual regression', { skip, concurrency: true }, () => {
         threshold: 0.2,
       });
       if (diffs > 0) {
-        const diffOutputBase = getDiffOutputBaseFileName(path);
         await mkdir(DIFF_DIRECTORY, { recursive: true });
         await Promise.all([
-          writeFile(`${diffOutputBase}-local.png`, PNG.sync.write(resizedLocalPNG)),
-          writeFile(`${diffOutputBase}-remote.png`, PNG.sync.write(resizedRemotePNG)),
-          writeFile(`${diffOutputBase}-diff.png`, PNG.sync.write(diff)),
+          writeFile(`${path}-local.png`, PNG.sync.write(resizedLocalPNG)),
+          writeFile(`${path}-remote.png`, PNG.sync.write(resizedRemotePNG)),
+          writeFile(`${path}-diff.png`, PNG.sync.write(diff)),
         ]);
       }
       assert.strictEqual(diffs, 0, `Expected "${path}" to visually match the live site.`);

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -54,21 +54,21 @@ describe('screenshot visual regression', { skip, concurrency: true }, async () =
 
   paths.forEach((path) => {
     test(path, async () => {
-      const localPNG = PNG.sync.read(await readFile(join(BRANCH_SNAPSHOTS_DIRECTORY, path)));
-      const remotePNG = PNG.sync.read(await readFile(join(MAIN_SNAPSHOTS_DIRECTORY, path)));
-      const width = Math.max(localPNG.width, remotePNG.width);
-      const height = Math.max(localPNG.height, remotePNG.height);
-      const resizedLocalPNG = fillImageToSize(localPNG, width, height);
-      const resizedRemotePNG = fillImageToSize(remotePNG, width, height);
+      const branchPNG = PNG.sync.read(await readFile(join(BRANCH_SNAPSHOTS_DIRECTORY, path)));
+      const mainPNG = PNG.sync.read(await readFile(join(MAIN_SNAPSHOTS_DIRECTORY, path)));
+      const width = Math.max(branchPNG.width, mainPNG.width);
+      const height = Math.max(branchPNG.height, mainPNG.height);
+      const resizedBranchPNG = fillImageToSize(branchPNG, width, height);
+      const resizedMainPNG = fillImageToSize(mainPNG, width, height);
       const diff = new PNG({ width, height });
-      const diffs = match(resizedLocalPNG.data, resizedRemotePNG.data, diff.data, width, height, {
+      const diffs = match(resizedBranchPNG.data, resizedMainPNG.data, diff.data, width, height, {
         threshold: 0.2,
       });
       if (diffs > 0) {
         await mkdir(DIFF_DIRECTORY, { recursive: true });
         await Promise.all([
-          writeFile(`${path}-local.png`, PNG.sync.write(resizedLocalPNG)),
-          writeFile(`${path}-remote.png`, PNG.sync.write(resizedRemotePNG)),
+          writeFile(`${path}-local.png`, PNG.sync.write(resizedBranchPNG)),
+          writeFile(`${path}-remote.png`, PNG.sync.write(resizedMainPNG)),
           writeFile(`${path}-diff.png`, PNG.sync.write(diff)),
         ]);
       }

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -65,11 +65,12 @@ describe('screenshot visual regression', { skip, concurrency: true }, async () =
         threshold: 0.2,
       });
       if (diffs > 0) {
+        const diffOutputBase = join(DIFF_DIRECTORY, path);
         await mkdir(DIFF_DIRECTORY, { recursive: true });
         await Promise.all([
-          writeFile(`${path}-local.png`, PNG.sync.write(resizedBranchPNG)),
-          writeFile(`${path}-remote.png`, PNG.sync.write(resizedMainPNG)),
-          writeFile(`${path}-diff.png`, PNG.sync.write(diff)),
+          writeFile(`${diffOutputBase}-local.png`, PNG.sync.write(resizedBranchPNG)),
+          writeFile(`${diffOutputBase}-remote.png`, PNG.sync.write(resizedMainPNG)),
+          writeFile(`${diffOutputBase}-diff.png`, PNG.sync.write(diff)),
         ]);
       }
       assert.strictEqual(diffs, 0, `Expected "${path}" to visually match the live site.`);

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -73,7 +73,7 @@ describe('screenshot visual regression', { skip, concurrency: true }, async () =
           writeFile(`${diffOutputBase}-diff.png`, PNG.sync.write(diff)),
         ]);
       }
-      assert.strictEqual(diffs, 0, `Expected "${path}" to visually match the live site.`);
+      assert.strictEqual(diffs, 0, `Expected "${path}" to visually match the main branch.`);
     });
   });
 });

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -18,8 +18,6 @@ const SNAPSHOT_DIRECTORY = 'tmp/screenshot/branches';
 const MAIN_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, 'main');
 const BRANCH_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, branch);
 
-const paths = await readdir(MAIN_SNAPSHOTS_DIRECTORY);
-
 function fillImageToSize(image, width, height) {
   if (image.width === width && image.height === height) {
     return image;
@@ -44,7 +42,12 @@ function fillImageToSize(image, width, height) {
 
 const skip = !!process.env.SKIP_VISUAL_REGRESSION_TEST;
 
-describe('screenshot visual regression', { skip, concurrency: true }, () => {
+describe('screenshot visual regression', { skip, concurrency: true }, async () => {
+  let paths = [];
+  try {
+    paths = await readdir(MAIN_SNAPSHOTS_DIRECTORY);
+  } catch {}
+
   it('has pages to test', () => {
     assert(paths.length);
   });


### PR DESCRIPTION
## 🛠 Summary of changes

Updates visual regression testing to avoid reliance on a hosted copy of the "main" branch, in anticipation that we may need to decommission current hosted references.

## 📜 Testing Plan

Build should pass.

Test locally by generating "snapshot" on each of `main` and this branch (`aduth-internal-visual-regression`) before running visual regression test:

1. `git checkout main`
2. `git checkout aduth-internal-visual-regression -- scripts/snapshot.js`
3. `scripts/snapshot.js`
4. `rm scripts/snapshot.js`
5. `git checkout aduth-internal-visual-regression`
6. `scripts/snapshot.js`
7. `ONLY_VISUAL_REGRESSION_TEST=true make test`