### PR TITLE
Remove references to Cloud.gov Pages branch previews

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,6 @@ jobs:
       - run:
           name: Checkout main
           command: git checkout main
-      - run:
-          name: Restore snapshot script
-          command: git checkout "$CIRCLE_BRANCH" -- scripts/snapshot.js
       - bundle-npm-install
       - build
       - snapshot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,18 +50,6 @@ When a pull request is submitted, a visual regression test will be automatically
 
 A failure of this status check only indicates that a visual change was detected. Depending on the types of changes being proposed, this may be expected. Anyone with access to the CircleCI dashboard can review the specific changes by following the status check "Details" link and comparing the set of screenshots under the "Artifacts" tab. If the visual changes are acceptable, the pull request can be merged, even if the status check is reported as a failure.
 
-## Branch documentation previews
-
-A copy of the local development documentation is published for opened pull requests, which can be shared with stakeholders as part of the review process.
-
-When a pull request is opened, a branch preview is created automatically, and should be available within a few minutes from the most recent commit.
-
-You can find the branch preview link by expanding the "All checks have passed" section of your pull request, and clicking the "Details" link for the successful `pages/build` check.
-
-![Screenshot with arrow pointing to the GitHub checks Cloud.gov Pages "Details" link](https://github.com/18F/identity-design-system/assets/1779930/345e9177-d915-429c-b2da-949d75fa86be)
-
-For security reasons, note that this feature is only available for pull requests submitted by contributors with write access to the repository.
-
 ## Releases
 
 When you're ready to release a new version of the `@18f/identity-design-system` package there are just a few steps to take.

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,6 @@ OUTPUT_DIR = $(DEFAULT_OUTPUT_DIR)
 PACKAGE_DIR = ./build
 NODE_BIN = ./node_modules/.bin
 
-# Cloud.gov Pages builds overwrite the output directory.
-ifdef SITE_PREFIX
-	OUTPUT_DIR = ./_site
-endif
-
 start:
 	$(MAKE) -j2 start-docs start-assets
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes all references to Cloud.gov Pages, including documented workflow for using branch previews.

This is being done in preparation to delete the Cloud.gov Pages site altogether, due to upcoming ATO requirements.