### PR TITLE
Remove raw color utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,35 @@
 
 ### Breaking Changes
 
-- [Prose](https://designsystem.digital.gov/components/prose/) styling overrides have been removed. Text formatting should now adhere to the defaults from the U.S. Web Design System.
-- Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/381))
+- [Prose](https://designsystem.digital.gov/components/prose/) styling overrides have been removed. Text formatting should now adhere to the defaults from the U.S. Web Design System. ([#390](https://github.com/18F/identity-design-system/pull/390))
+- Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/387))
   - Support was indirectly dropped in [v7.0.0](https://github.com/18F/identity-design-system/releases/tag/v7.0.0) via the upgrade to USWDS [v3.0.0](https://designsystem.digital.gov/about/releases/#version-uswds-300), which similarly ended explicit support for Internet Explorer. This package had continued to include Internet Explorer in its [Browserslist](https://browsersl.ist/) configuration, but this has now been removed.
+- Remove utility classes for raw color tokens. ([#405](https://github.com/18F/identity-style-guide/pull/405))
+  - These colors were usually incorrect because they were using U.S. Web Design System defaults instead of the Login.gov Design System color set.
+  - In most common cases, these should be replaced with stateful equivalents ("success" instead of "green") or theme colors ("base" instead of "gray-50").
+  - Applies to the following utilities:
+    - Background color (`bg-*`)
+    - Border color (`border-*`)
+    - Text color (`text-*`)
+    - Outline color (`outline-*`)
+    - Text underline color (`underline-*`)
+  - The following colors are removed:
+    - `red` (use `error` instead)
+    - `orange`
+    - `gold`
+    - `yellow` (use `warning` instead)
+    - `green` (use `success` instead)
+    - `mint`
+    - `cyan`
+    - `blue` (use `primary` instead)
+    - `indigo`
+    - `violet`
+    - `magenta`
+    - `gray-10` (use `base-lighter` instead)
+    - `gray-30` (use `base-light` instead)
+    - `gray-50` (use `base` instead)
+    - `gray-70` (use `base-darker` instead)
+    - `gray-90` (use `base-darkest` instead)
 
 ### Internal
 

--- a/docs/_components/icon-list.md
+++ b/docs/_components/icon-list.md
@@ -10,7 +10,7 @@ lead: An icon list reinforces the meaning and visibility of individual list item
 {% capture example %}
 <ul class="usa-icon-list usa-icon-list--size-md">
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-green">
+    <div class="usa-icon-list__icon text-success">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_circle"></use>
       </svg>
@@ -27,7 +27,7 @@ lead: An icon list reinforces the meaning and visibility of individual list item
     </div>
   </li>
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-green">
+    <div class="usa-icon-list__icon text-success">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_circle"></use>
       </svg>
@@ -42,7 +42,7 @@ lead: An icon list reinforces the meaning and visibility of individual list item
     </div>
   </li>
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-green">
+    <div class="usa-icon-list__icon text-success">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_circle"></use>
       </svg>
@@ -64,12 +64,12 @@ lead: An icon list reinforces the meaning and visibility of individual list item
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
 
-## Simple 
+## Simple
 
 {% capture example %}
 <ul class="usa-icon-list usa-icon-list--size-md">
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-green">
+    <div class="usa-icon-list__icon text-success">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_circle"></use>
       </svg>
@@ -79,7 +79,7 @@ lead: An icon list reinforces the meaning and visibility of individual list item
     </div>
   </li>
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-green">
+    <div class="usa-icon-list__icon text-success">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_circle"></use>
       </svg>
@@ -87,7 +87,7 @@ lead: An icon list reinforces the meaning and visibility of individual list item
     <div class="usa-icon-list__content">Stay six feet away from others</div>
   </li>
   <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon text-red">
+    <div class="usa-icon-list__icon text-error">
       <svg class="usa-icon" aria-hidden="true" role="img">
         <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#cancel"></use>
       </svg>

--- a/src/scss/packages/_uswds-core.scss
+++ b/src/scss/packages/_uswds-core.scss
@@ -59,7 +59,8 @@ $site-palette: (
   // Colors
   // ----------------------------------------
   // Palettes
-  $global-color-palettes: ('palette-color-default', 'palette-color-state') !default,
+  $global-color-palettes: ('palette-color-required', 'palette-color-theme', 'palette-color-state')
+    !default,
   // Base colors
   $theme-color-base-family: 'grey' !default,
   $theme-color-base-lightest: map.get($site-palette, 'site-lightest-grey') !default,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates theme configuration to remove color palettes for anything other than "required", "theme", or "state", effectively removing ad hoc color usage (e.g. green) in favor of semantic color tokens (e.g. success).

**Why?**

- In almost all cases, the state colors are more semantic in representing the intent of the color
- The colors were wrong, since we weren't customizing the underlying [system colors](https://designsystem.digital.gov/design-tokens/color/system-tokens/), e.g. `text-green` was `#538200` vs. `text-success` as `#18852e`
   - This was noticed by @Sgtpluck in https://github.com/18F/identity-dev-docs/pull/449
- Slight reduction in stylesheet size