### PR TITLE
Add missing BEM base class in Image Example component code

### DIFF
--- a/docs/_components/image-example.md
+++ b/docs/_components/image-example.md
@@ -9,7 +9,7 @@ This is not a component in the USWDS design system.
 
 
 {% capture example %}
-<div class="usa-image-example--correct">
+<div class="usa-image-example usa-image-example--correct">
   <figure class="usa-image-example__figure">
     <img class="usa-image-example__image" alt="correct example, use dark background" src="{{ site.baseurl }}/img/ID-dos-donts_ID_do-02.png" />
     <figcaption class="usa-image-example__figcaption">


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes the Image Example component documentation to include the BEM "block" class which the `usa-image-example--correct` modifier class is expected to modify.

**Why?**

- In case new default styles are added to all `usa-image-example` subvariants, the base class needs to be present
- This component code is often used as reference ([example](https://github.com/18F/identity-dev-docs/pull/449#discussion_r1478847456))
