### PR TITLE
Add TypeScript type-checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
     - `gray-70` (use `base-darker` instead)
     - `gray-90` (use `base-darkest` instead)
 
+### Bug Fixes
+
+- Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`.
+
 ### Internal
 
 - Replace code compiler Babel with ESBuild. ([#387](https://github.com/18F/identity-style-guide/pull/381))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### Bug Fixes
 
-- Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`.
+- Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`. ([#407](https://github.com/18F/identity-design-system/pull/407))
 
 ### Internal
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ validate-package-lock: package.json package-lock.json
 
 validate-lockfiles: validate-gemfile-lock validate-package-lock
 
+typecheck:
+	npm run typecheck
+
 optimize-svg:
 	$(NODE_BIN)/svgo --config svgo.config.js -f src/img
 
@@ -33,7 +36,7 @@ optimize-assets: optimize-svg
 lint-optimized-assets: optimize-assets
 	(! git diff --name-only | grep "\.svg$$") || (echo "Error: Optimize assets using 'make optimize-assets'"; exit 1)
 
-lint: build-package validate-lockfiles lint-optimized-assets
+lint: build-package validate-lockfiles lint-optimized-assets typecheck
 	npm run lint
 
 build: build-docs build-assets build-package
@@ -87,6 +90,7 @@ clean:
 	validate-gemfile-lock \
 	validate-package-lock \
 	validate-lockfiles \
+	typecheck \
 	optimize-svg \
 	optimize-assets \
 	lint-optimized-assets \

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,10 @@
         "@18f/eslint-plugin-identity": "^2.0.0",
         "@18f/identity-build-sass": "^2.0.0",
         "@18f/identity-stylelint-config": "^2.0.0",
+        "@types/html_codesniffer": "^2.5.4",
+        "@types/pixelmatch": "^5.2.6",
+        "@types/pngjs": "^6.0.4",
+        "@types/uswds__uswds": "^3.3.3",
         "browserslist": "^4.22.2",
         "esbuild": "^0.19.9",
         "eslint": "^8.39.0",
@@ -28,7 +32,8 @@
         "prettier": "^2.8.8",
         "puppeteer": "^21.6.1",
         "stylelint": "^15.6.1",
-        "svgo": "^3.0.2"
+        "svgo": "^3.0.2",
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=12",
@@ -816,6 +821,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/html_codesniffer": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/html_codesniffer/-/html_codesniffer-2.5.4.tgz",
+      "integrity": "sha512-l7LZ5umKNiJIdq5b9Z8WDhJ2IKd8MZejapCssvdKF7RCmLQDx3bcEDF2T8PwGyK6rhcX/ggovd2sqYICywGzOA==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -833,7 +844,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
       "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -842,6 +852,30 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/pixelmatch": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
+      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.4.tgz",
+      "integrity": "sha512-atAK9xLKOnxiuArxcHovmnOUUGBZOQ3f0vCf43FnoKs6XnqiambT1kkJWmdo71IR+BoXSh+CueeFR0GfH3dTlQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/uswds__uswds": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uswds__uswds/-/uswds__uswds-3.3.3.tgz",
+      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw==",
       "dev": true
     },
     "node_modules/@types/yauzl": {
@@ -6597,6 +6631,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -6626,8 +6673,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -7358,6 +7404,12 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
+    "@types/html_codesniffer": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/html_codesniffer/-/html_codesniffer-2.5.4.tgz",
+      "integrity": "sha512-l7LZ5umKNiJIdq5b9Z8WDhJ2IKd8MZejapCssvdKF7RCmLQDx3bcEDF2T8PwGyK6rhcX/ggovd2sqYICywGzOA==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -7375,7 +7427,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
       "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -7384,6 +7435,30 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/pixelmatch": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
+      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/pngjs": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.4.tgz",
+      "integrity": "sha512-atAK9xLKOnxiuArxcHovmnOUUGBZOQ3f0vCf43FnoKs6XnqiambT1kkJWmdo71IR+BoXSh+CueeFR0GfH3dTlQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/uswds__uswds": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uswds__uswds/-/uswds__uswds-3.3.3.tgz",
+      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw==",
       "dev": true
     },
     "@types/yauzl": {
@@ -11481,6 +11556,12 @@
         "is-typed-array": "^1.1.9"
       }
     },
+    "typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -11507,8 +11588,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "start": "make start",
     "clean": "make clean",
     "lint": "run-p lint:*",
+    "typecheck": "tsc",
     "test": "make test",
     "build": "run-p build:docs build:pkg",
     "pages": "make build-assets",
@@ -78,6 +79,10 @@
     "@18f/eslint-plugin-identity": "^2.0.0",
     "@18f/identity-build-sass": "^2.0.0",
     "@18f/identity-stylelint-config": "^2.0.0",
+    "@types/html_codesniffer": "^2.5.4",
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.4",
+    "@types/uswds__uswds": "^3.3.3",
     "browserslist": "^4.22.2",
     "esbuild": "^0.19.9",
     "eslint": "^8.39.0",
@@ -91,6 +96,7 @@
     "prettier": "^2.8.8",
     "puppeteer": "^21.6.1",
     "stylelint": "^15.6.1",
-    "svgo": "^3.0.2"
+    "svgo": "^3.0.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/src/js/auto.js
+++ b/src/js/auto.js
@@ -3,7 +3,7 @@ import * as components from './components';
 function initComponents() {
   const target = document.body;
   Object.keys(components).forEach((key) => {
-    const behavior = components[key];
+    const behavior = components[/** @type {keyof components} */ (key)];
     behavior.on(target);
   });
 }

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -1,14 +1,19 @@
 import accordion from '@uswds/uswds/js/usa-accordion';
 import banner from '@uswds/uswds/js/usa-banner';
+import button from '@uswds/uswds/js/usa-button';
 import characterCount from '@uswds/uswds/js/usa-character-count';
 import comboBox from '@uswds/uswds/js/usa-combo-box';
 import datePicker from '@uswds/uswds/js/usa-date-picker';
 import dateRangePicker from '@uswds/uswds/js/usa-date-range-picker';
 import fileInput from '@uswds/uswds/js/usa-file-input';
 import footer from '@uswds/uswds/js/usa-footer';
+import inPageNavigation from '@uswds/uswds/js/usa-in-page-navigation';
+import inputMask from '@uswds/uswds/js/usa-input-mask';
+import languageSelector from '@uswds/uswds/js/usa-language-selector';
 import modal from '@uswds/uswds/js/usa-modal';
 import header from '@uswds/uswds/js/usa-header';
 import password from '@uswds/uswds/js/_usa-password';
+import range from '@uswds/uswds/js/usa-range';
 import search from '@uswds/uswds/js/usa-search';
 import skipnav from '@uswds/uswds/js/usa-skipnav';
 import timePicker from '@uswds/uswds/js/usa-time-picker';
@@ -19,15 +24,20 @@ import validation from '@uswds/uswds/js/usa-validation';
 export {
   accordion,
   banner,
+  button,
   characterCount,
   comboBox,
   datePicker,
   dateRangePicker,
   fileInput,
   footer,
+  inPageNavigation,
+  inputMask,
+  languageSelector,
   modal,
   header,
   password,
+  range,
   search,
   skipnav,
   timePicker,

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -45,13 +45,9 @@ describe('accessibility', () => {
       await page.addScriptTag({ path: require.resolve('html_codesniffer/build/HTMLCS.js') });
       const messages = await page.evaluate(
         () =>
-          new Promise((resolve, reject) => {
-            window.HTMLCS.process('WCAG2AA', window.document, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve(window.HTMLCS.getMessages());
-              }
+          new Promise((resolve) => {
+            window.HTMLCS.process('WCAG2AA', window.document.body, () => {
+              resolve(window.HTMLCS.getMessages());
             });
           }),
       );

--- a/test/components/index.test.js
+++ b/test/components/index.test.js
@@ -4,18 +4,25 @@ import { readFile } from 'node:fs/promises';
 import { basename, dirname } from 'node:path';
 import glob from 'fast-glob';
 
+/**
+ * @param {string} str
+ *
+ * @returns {string}
+ */
 const camelCase = (str) => str.replace(/-([a-z])/g, (_match, character) => character.toUpperCase());
 
 describe('components', () => {
   it('re-exports all uswds components', async () => {
     const localComponentsFileContent = await readFile('./build/esm/components/index.js', 'utf-8');
-    const localComponentKeys = Array.from(
-      localComponentsFileContent.matchAll(/import ([a-z]+)/gi),
-    ).map((match) => match[1]);
+    const localComponentKeys = Array.from(localComponentsFileContent.matchAll(/import ([a-z]+)/gi))
+      .map((match) => match[1])
+      .sort();
     const uswdsComponentKeys = glob
-      .sync('../../node_modules/@uswds/uswds/packages/*/src/index.js')
-      .map((path) => camelCase(basename(dirname(dirname(path))).replace(/^_?usa-/, '')));
+      .sync('./node_modules/@uswds/uswds/packages/*/src/index.js')
+      .map((path) => camelCase(basename(dirname(dirname(path))).replace(/^_?usa-/, '')))
+      .sort();
 
-    assert.ok(uswdsComponentKeys.every((key) => localComponentKeys[key]));
+    assert(uswdsComponentKeys.length);
+    assert.deepStrictEqual(localComponentKeys, uswdsComponentKeys);
   });
 });

--- a/test/components/index.test.js
+++ b/test/components/index.test.js
@@ -5,9 +5,11 @@ import { basename, dirname } from 'node:path';
 import glob from 'fast-glob';
 
 /**
+ * Converts a string to camel case.
+ *
  * @param {string} str
  *
- * @returns {string}
+ * @return {string}
  */
 const camelCase = (str) => str.replace(/-([a-z])/g, (_match, character) => character.toUpperCase());
 

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -19,6 +19,8 @@ const MAIN_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, 'main');
 const BRANCH_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, branch);
 
 /**
+ * Resizes an image to the given dimensions.
+ *
  * @param {import('pngjs').PNGWithMetadata} image
  * @param {number} width
  * @param {number} height

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -18,6 +18,13 @@ const SNAPSHOT_DIRECTORY = 'tmp/screenshot/branches';
 const MAIN_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, 'main');
 const BRANCH_SNAPSHOTS_DIRECTORY = join(SNAPSHOT_DIRECTORY, branch);
 
+/**
+ * @param {import('pngjs').PNGWithMetadata} image
+ * @param {number} width
+ * @param {number} height
+ *
+ * @return {import('pngjs').PNG}
+ */
 function fillImageToSize(image, width, height) {
   if (image.width === width && image.height === height) {
     return image;
@@ -43,6 +50,7 @@ function fillImageToSize(image, width, height) {
 const skip = !!process.env.SKIP_VISUAL_REGRESSION_TEST;
 
 describe('screenshot visual regression', { skip, concurrency: true }, async () => {
+  /** @type {string[]} */
   let paths = [];
   try {
     paths = await readdir(MAIN_SNAPSHOTS_DIRECTORY);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "module": "ESNext",
+    "target": "ESNext",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["typings/*"]
+    }
+  },
+  "exclude": ["build", "dist", "packages"]
+}

--- a/typings/uswds__uswds.d.ts
+++ b/typings/uswds__uswds.d.ts
@@ -1,0 +1,2 @@
+declare module '@uswds/uswds/js/usa-button';
+declare module '@uswds/uswds/js/usa-range';


### PR DESCRIPTION
## 🛠 Summary of changes

Adds TypeScript type-checking for existing JavaScript files.

As evidenced by the included changes, this helped highlight a couple legitimate issues:

- The test for ensuring all components are exported was not working as intended, and therefore there were several components not being exported
- The HTML_CodeSniffer test incorrectly assumed there would be an error argument passed in the callback, which doesn't exist

## 📜 Testing Plan

```
npm run typecheck
```