### PR TITLE
Optimize CI visual regression snapshotting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,11 @@ commands:
           paths:
             - ~/.npm
             - ~/.bundler
-  build:
+  build-docs:
     steps:
       - run:
           name: Build assets and site
-          command: make build
+          command: make -j2 build-assets build-docs
   snapshot:
     steps:
       - run:
@@ -82,14 +82,14 @@ jobs:
           name: Checkout main
           command: git checkout main
       - bundle-npm-install
-      - build
+      - build-docs
       - snapshot
   snapshot-branch:
     executor: ruby_browsers
     steps:
       - checkout
       - bundle-npm-install
-      - build
+      - build-docs
       - snapshot
   visual-regression:
     executor: ruby_browsers

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -18,25 +18,24 @@ const branch = (await exec('git branch --show-current')).stdout.trim();
  * @param {string} url
  */
 async function getScreenshot(page, url) {
-  await page.goto(url, { waitUntil: 'networkidle0' });
+  await page.goto(url);
   return page.screenshot({ fullPage: true, optimizeForSpeed: true });
 }
 
 const esbuildContext = await esbuild.context({});
 const { port } = await esbuildContext.serve({ servedir: 'dist' });
 const browser = await puppeteer.launch({ headless: 'new' });
-const browserContext = await browser.createIncognitoBrowserContext();
 const localURL = `http://localhost:${port}/`;
 const outputDirectory = join('tmp/screenshot/branches', branch);
+const page = await browser.newPage();
 
 await mkdir(outputDirectory, { recursive: true });
-await Promise.all(
-  paths.map(async (path) => {
-    const page = await browserContext.newPage();
-    const screenshot = await getScreenshot(page, localURL + path);
-    const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
-    process.stdout.write(`Writing ${filename}...\n`);
-    await writeFile(filename, screenshot);
-  }),
-);
-await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);
+for await (const path of paths) {
+  const screenshot = await getScreenshot(page, localURL + path);
+  const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
+  process.stdout.write(`Writing ${filename}...\n`);
+  await writeFile(filename, screenshot);
+}
+
+browser.close();
+esbuildContext.dispose();

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -25,17 +25,19 @@ async function getScreenshot(page, url) {
 const esbuildContext = await esbuild.context({});
 const { port } = await esbuildContext.serve({ servedir: 'dist' });
 const browser = await puppeteer.launch({ headless: 'new' });
+const browserContext = await browser.createIncognitoBrowserContext();
 const localURL = `http://localhost:${port}/`;
 const outputDirectory = join('tmp/screenshot/branches', branch);
-const page = await browser.newPage();
 
 await mkdir(outputDirectory, { recursive: true });
-for await (const path of paths) {
-  const screenshot = await getScreenshot(page, localURL + path);
-  const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
-  process.stdout.write(`Writing ${filename}...\n`);
-  await writeFile(filename, screenshot);
-}
-
-browser.close();
-esbuildContext.dispose();
+await Promise.all(
+  paths.map(async (path) => {
+    const page = await browserContext.newPage();
+    const screenshot = await getScreenshot(page, localURL + path);
+    const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
+    process.stdout.write(`Writing ${filename}...\n`);
+    await writeFile(filename, screenshot);
+    await page.close();
+  }),
+);
+await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -25,14 +25,13 @@ async function getScreenshot(page, url) {
 const esbuildContext = await esbuild.context({});
 const { port } = await esbuildContext.serve({ servedir: 'dist' });
 const browser = await puppeteer.launch({ headless: 'new' });
-const browserContext = await browser.createIncognitoBrowserContext();
 const localURL = `http://localhost:${port}/`;
 const outputDirectory = join('tmp/screenshot/branches', branch);
 
 await mkdir(outputDirectory, { recursive: true });
 await Promise.all(
   paths.map(async (path) => {
-    const page = await browserContext.newPage();
+    const page = await browser.newPage();
     const screenshot = await getScreenshot(page, localURL + path);
     const filename = join(outputDirectory, `${basename(path, extname(path))}.png`);
     process.stdout.write(`Writing ${filename}...\n`);
@@ -40,4 +39,4 @@ await Promise.all(
     await page.close();
   }),
 );
-await Promise.all([browserContext.close(), browser.close(), esbuildContext.dispose()]);
+await Promise.all([browser.close(), esbuildContext.dispose()]);


### PR DESCRIPTION
## 🛠 Summary of changes

Adjusts continuous integration workflow to optimize visual regressions.

Specifically:

- Ensure that parallelized `page` are closed once completed to avoid memory leak
- Avoid using `networkidle0`, which effectively incurs a `sleep(500ms)` ([docs](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent))
- Avoid unnecessary NPM package build and limit build to documentation site
   - Parallelize tasks for building documentation site
- Avoid creating an Incognito browsing context, which seems to incur a noticeable start-up cost, and should hopefully not be necessary anymore with changes in #403 and https://github.com/18F/identity-design-system/pull/402#issuecomment-1915477963

### Performance Impact

On average, this should save upward of 10 seconds from the "visual_regression" workflow.

See `snapshot-branch` and `snapshot-main` timings in below builds:

- [Before](https://app.circleci.com/pipelines/github/18F/identity-design-system/1415/workflows/efdc2226-2c9d-4f23-858f-733111ccbebd?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) (min 46s, max 46s)
- [After (1)](https://app.circleci.com/pipelines/github/18F/identity-design-system/1420/workflows/c540ffa5-ec38-48f0-8294-c098092f91ff) (min 32s, max 37s)
- [After (2)](https://app.circleci.com/pipelines/github/18F/identity-design-system/1421/workflows/e6ecea1b-d130-42d1-a8c7-c6845e6880dc) (min 36s, max 39s)
- [After (3)](https://app.circleci.com/pipelines/github/18F/identity-design-system/1422/workflows/ebd6537c-09cc-47a6-8749-9fef287d7470) (min 36s, max 46s)
- [After (4)](https://app.circleci.com/pipelines/github/18F/identity-design-system/1423/workflows/f8490734-21b0-482e-be39-1952f86a408f?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) (min 33s, max 36s)

## 📜 Testing Plan

Verify build passes.