### PR TITLE
Add TypeScript types for JavaScript components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
   - `close.svg` (use `close` icon instead)
   - `hero.png`
 
+### New Features
+
+- Add TypeScript types for JavaScript components.
+
 ### Bug Fixes
 
 - Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`. ([#407](https://github.com/18F/identity-design-system/pull/407))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### New Features
 
-- Add TypeScript types for JavaScript components.
+- Add TypeScript types for JavaScript components. ([#413](https://github.com/18F/identity-design-system/pull/413))
 
 ### Bug Fixes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,67 @@
-export {
-  accordion,
-  banner,
-  characterCount,
-  comboBox,
-  datePicker,
-  dateRangePicker,
-  fileInput,
-  footer,
-  inPageNavigation,
-  inputMask,
-  languageSelector,
-  modal,
-  navigation as header,
-  password,
-  search,
-  skipnav,
-  timePicker,
-  table,
-  tooltip,
-  validator as validation,
+import {
+  accordion as baseAccordion,
+  banner as baseBanner,
+  characterCount as baseCharacterCount,
+  comboBox as baseComboBox,
+  datePicker as baseDatePicker,
+  dateRangePicker as baseDateRangePicker,
+  fileInput as baseFileInput,
+  footer as baseFooter,
+  inPageNavigation as baseInPageNavigation,
+  inputMask as baseInputMask,
+  languageSelector as baseLanguageSelector,
+  modal as baseModal,
+  navigation as baseHeader,
+  password as basePassword,
+  search as baseSearch,
+  skipnav as baseSkipnav,
+  timePicker as baseTimePicker,
+  table as baseTable,
+  tooltip as baseTooltip,
+  validator as baseValidation,
 } from '@uswds/uswds';
 
-export interface button {
-  on(target?: HTMLElement): void;
-  off(target?: HTMLElement): void;
+type ComponentLifecycle = (target?: HTMLElement) => any;
+
+interface BaseComponent {
+  on: ComponentLifecycle;
+  off: ComponentLifecycle;
 }
 
-export interface range {
-  on(target?: HTMLElement): void;
-  off(target?: HTMLElement): void;
+interface Button extends BaseComponent {}
+
+interface Range extends BaseComponent {
   updateCallout(targetRange: HTMLInputElement): void;
 }
+
+type Tooltip = typeof baseTooltip &
+  BaseComponent & {
+    show(
+      tooltipBody: HTMLElement,
+      tooltipTrigger: Element,
+      position: 'top' | 'right' | 'left' | 'bottom',
+    ): void;
+  };
+
+export const accordion: typeof baseAccordion & BaseComponent;
+export const banner: typeof baseBanner & BaseComponent;
+export const button: Button;
+export const characterCount: typeof baseCharacterCount & BaseComponent;
+export const comboBox: typeof baseComboBox & BaseComponent;
+export const datePicker: typeof baseDatePicker & BaseComponent;
+export const dateRangePicker: typeof baseDateRangePicker & BaseComponent;
+export const fileInput: typeof baseFileInput & BaseComponent;
+export const footer: typeof baseFooter & BaseComponent;
+export const inPageNavigation: typeof baseInPageNavigation & BaseComponent;
+export const inputMask: typeof baseInputMask & BaseComponent;
+export const languageSelector: typeof baseLanguageSelector & BaseComponent;
+export const modal: typeof baseModal & BaseComponent;
+export const header: typeof baseHeader & BaseComponent;
+export const password: typeof basePassword & BaseComponent;
+export const range: Range;
+export const search: typeof baseSearch & BaseComponent;
+export const skipnav: typeof baseSkipnav & BaseComponent;
+export const timePicker: typeof baseTimePicker & BaseComponent;
+export const table: typeof baseTable & BaseComponent;
+export const tooltip: Tooltip;
+export const validation: typeof baseValidation & BaseComponent;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+export {
+  accordion,
+  banner,
+  characterCount,
+  comboBox,
+  datePicker,
+  dateRangePicker,
+  fileInput,
+  footer,
+  inPageNavigation,
+  inputMask,
+  languageSelector,
+  modal,
+  navigation as header,
+  password,
+  search,
+  skipnav,
+  timePicker,
+  table,
+  tooltip,
+  validator as validation,
+} from '@uswds/uswds';
+
+export interface button {
+  on(target?: HTMLElement): void;
+  off(target?: HTMLElement): void;
+}
+
+export interface range {
+  on(target?: HTMLElement): void;
+  off(target?: HTMLElement): void;
+  updateCallout(targetRange: HTMLInputElement): void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "8.1.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "@types/uswds__uswds": "^3.3.3",
         "@uswds/uswds": "^3.7.1"
       },
       "devDependencies": {
@@ -18,7 +19,6 @@
         "@types/html_codesniffer": "^2.5.4",
         "@types/pixelmatch": "^5.2.6",
         "@types/pngjs": "^6.0.4",
-        "@types/uswds__uswds": "^3.3.3",
         "browserslist": "^4.22.2",
         "esbuild": "^0.19.9",
         "eslint": "^8.39.0",
@@ -989,8 +989,7 @@
     "node_modules/@types/uswds__uswds": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@types/uswds__uswds/-/uswds__uswds-3.3.3.tgz",
-      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw==",
-      "dev": true
+      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -7511,8 +7510,7 @@
     "@types/uswds__uswds": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@types/uswds__uswds/-/uswds__uswds-3.3.3.tgz",
-      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw==",
-      "dev": true
+      "integrity": "sha512-lg5rcWgVvFFoJ+CY+HH6IReBJVT4R/5JXABfDz8NDoS1KDKa86z/XUmaDNK6Frb90n12fPRUF95qegL8tY6pPw=="
     },
     "@types/yauzl": {
       "version": "2.10.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "homepage": "https://github.com/18F/identity-design-system#readme",
   "dependencies": {
+    "@types/uswds__uswds": "^3.3.3",
     "@uswds/uswds": "^3.7.1"
   },
   "devDependencies": {
@@ -82,7 +83,6 @@
     "@types/html_codesniffer": "^2.5.4",
     "@types/pixelmatch": "^5.2.6",
     "@types/pngjs": "^6.0.4",
-    "@types/uswds__uswds": "^3.3.3",
     "browserslist": "^4.22.2",
     "esbuild": "^0.19.9",
     "eslint": "^8.39.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "./dist/assets/js/main": "./dist/assets/js/main.js",
     "./dist/assets/js/main.js": "./dist/assets/js/main.js"
   },
+  "types": "./index.d.ts",
   "sideEffects": [
     "./dist/assets/js/main.js",
     "./build/*/auto.js"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepublishOnly": "make lint && make clean && make build-assets build-package"
   },
   "files": [
+    "index.d.ts",
     "build",
     "dist/assets/**/*",
     "packages",


### PR DESCRIPTION
## 🛠 Summary of changes

Includes TypeScript types in the published NPM package for JavaScript components.

This basically republishes `@uswds/uswds` DefinitelyTyped types, with corrected LGDS aliases and missing type definitions for newer components. There were a handful of different errors with the DefinitelyTyped types, and I may work to propose an upstream patch to resolve these, which would hopefully allow the typings of this package to be simplified.

This doesn't include enforcement that the typings exactly reflect the exported components, which I'd like to add in future iterations to provide similar guarantees to what's asserted in [`test/components/index.test.js`](https://github.com/18F/identity-design-system/blob/main/test/components/index.test.js).

## 📜 Testing Plan

I tested this in `identity-idp` by changing its `@18f/identity-design-system` dependency to point to the local filesystem copy and verifying that component references include autocompletion and type validation.

```diff
diff --git a/package.json b/package.json
index b6af77174..be85052f8 100644
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:css": "build-sass app/assets/stylesheets/*.css.scss app/components/*.scss --load-path=app/assets/stylesheets --out-dir=app/assets/builds"
   },
   "dependencies": {
-    "@18f/identity-design-system": "^8.1.2",
+    "@18f/identity-design-system": "file:../identity-design-system",
     "@babel/core": "^7.20.7",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
```

In `identity-idp`:

1. Apply patch above
2. Clear and reinstall dependencies: `rm -rf node_modules && yarn`
3. Run TypeCheck: `yarn typecheck`
4. (Optional) Check auto-completion support in supported IDE such as VS Code

Example (`app/javascript/packages/clipboard-button/clipboard-button-element.ts`):

![image](https://github.com/18F/identity-design-system/assets/1779930/cdbde03d-0bec-44d2-8e7a-0d1f1be6a40f)
