### PR TITLE
Align JavaScript component names with USWDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@
     - `close.svg` (use `close` icon instead)
     - `hero.png`
 - Align JavaScript component names with U.S. Web Design System. ([#414](https://github.com/18F/identity-design-system/pull/414))
-  - `header` is renamed `navigation`
-  - `validation` is renamed `validator`
+  - `header` is now named `navigation`
+  - `validation` is now named `validator`
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
     - `close-primary.svg` (use `close` icon instead)
     - `close.svg` (use `close` icon instead)
     - `hero.png`
+- Align JavaScript component names with U.S. Web Design System. ([#414](https://github.com/18F/identity-design-system/pull/414))
+  - `header` is renamed `navigation`
+  - `validation` is renamed `validator`
 
 ### Improvements
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,14 +11,14 @@ import {
   inputMask as baseInputMask,
   languageSelector as baseLanguageSelector,
   modal as baseModal,
-  navigation as baseHeader,
+  navigation as baseNavigation,
   password as basePassword,
   search as baseSearch,
   skipnav as baseSkipnav,
   timePicker as baseTimePicker,
   table as baseTable,
   tooltip as baseTooltip,
-  validator as baseValidation,
+  validator as baseValidator,
 } from '@uswds/uswds';
 
 type ComponentLifecycle = (target?: HTMLElement) => any;
@@ -56,7 +56,7 @@ export const inPageNavigation: typeof baseInPageNavigation & BaseComponent;
 export const inputMask: typeof baseInputMask & BaseComponent;
 export const languageSelector: typeof baseLanguageSelector & BaseComponent;
 export const modal: typeof baseModal & BaseComponent;
-export const header: typeof baseHeader & BaseComponent;
+export const navigation: typeof baseNavigation & BaseComponent;
 export const password: typeof basePassword & BaseComponent;
 export const range: Range;
 export const search: typeof baseSearch & BaseComponent;
@@ -64,4 +64,4 @@ export const skipnav: typeof baseSkipnav & BaseComponent;
 export const timePicker: typeof baseTimePicker & BaseComponent;
 export const table: typeof baseTable & BaseComponent;
 export const tooltip: Tooltip;
-export const validation: typeof baseValidation & BaseComponent;
+export const validator: typeof baseValidator & BaseComponent;

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -11,7 +11,7 @@ import inPageNavigation from '@uswds/uswds/js/usa-in-page-navigation';
 import inputMask from '@uswds/uswds/js/usa-input-mask';
 import languageSelector from '@uswds/uswds/js/usa-language-selector';
 import modal from '@uswds/uswds/js/usa-modal';
-import header from '@uswds/uswds/js/usa-header';
+import navigation from '@uswds/uswds/js/usa-header';
 import password from '@uswds/uswds/js/_usa-password';
 import range from '@uswds/uswds/js/usa-range';
 import search from '@uswds/uswds/js/usa-search';
@@ -19,7 +19,7 @@ import skipnav from '@uswds/uswds/js/usa-skipnav';
 import timePicker from '@uswds/uswds/js/usa-time-picker';
 import table from '@uswds/uswds/js/usa-table';
 import tooltip from '@uswds/uswds/js/usa-tooltip';
-import validation from '@uswds/uswds/js/usa-validation';
+import validator from '@uswds/uswds/js/usa-validation';
 
 export {
   accordion,
@@ -35,7 +35,7 @@ export {
   inputMask,
   languageSelector,
   modal,
-  header,
+  navigation,
   password,
   range,
   search,
@@ -43,5 +43,5 @@ export {
   timePicker,
   table,
   tooltip,
-  validation,
+  validator,
 };

--- a/test/components/index.test.js
+++ b/test/components/index.test.js
@@ -16,7 +16,7 @@ describe('components', () => {
       uswdsComponentsIndex.match(/module\.exports = \{([\s\S]+)\};/)
     );
     const uswdsComponentKeys = Array.from(exports.matchAll(/(?:\s+([a-zA-Z]+)),/g))
-      .map((match) => match[1])
+      .map(([, capturedKey]) => capturedKey)
       .sort();
 
     assert(uswdsComponentKeys.length);

--- a/test/components/index.test.js
+++ b/test/components/index.test.js
@@ -1,17 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { basename, dirname } from 'node:path';
-import glob from 'fast-glob';
-
-/**
- * Converts a string to camel case.
- *
- * @param {string} str
- *
- * @return {string}
- */
-const camelCase = (str) => str.replace(/-([a-z])/g, (_match, character) => character.toUpperCase());
 
 describe('components', () => {
   it('re-exports all uswds components', async () => {
@@ -19,9 +8,15 @@ describe('components', () => {
     const localComponentKeys = Array.from(localComponentsFileContent.matchAll(/import ([a-z]+)/gi))
       .map((match) => match[1])
       .sort();
-    const uswdsComponentKeys = glob
-      .sync('./node_modules/@uswds/uswds/packages/*/src/index.js')
-      .map((path) => camelCase(basename(dirname(dirname(path))).replace(/^_?usa-/, '')))
+    const uswdsComponentsIndex = await readFile(
+      'node_modules/@uswds/uswds/packages/uswds-core/src/js/index.js',
+      'utf-8',
+    );
+    const [, exports] = /** @type {RegExpMatchArray} */ (
+      uswdsComponentsIndex.match(/module\.exports = \{([\s\S]+)\};/)
+    );
+    const uswdsComponentKeys = Array.from(exports.matchAll(/(?:\s+([a-zA-Z]+)),/g))
+      .map((match) => match[1])
       .sort();
 
     assert(uswdsComponentKeys.length);


### PR DESCRIPTION
## 🛠 Summary of changes

Updates JavaScript components to ensure that their names match those exported by USWDS. This is an inconsistency within USWDS itself between its package directory names and the corresponding exported JavaScript component name.

**Why?**

- This package is meant to operate as a drop-in replacement for USWDS, so its exported members should match 1-to-1

## 📜 Testing Plan

Verify the modified test passes:

```
npm run build
node --test test/components/index.test.js
```