### PR TITLE
Fix direct imports to prose styles

### DIFF
--- a/src/scss/packages/_usa-prose.scss
+++ b/src/scss/packages/_usa-prose.scss
@@ -1,1 +1,0 @@
-@forward 'usa-prose/index';

--- a/src/scss/packages/usa-prose/src/_styles.scss
+++ b/src/scss/packages/usa-prose/src/_styles.scss
@@ -1,2 +1,0 @@
-@forward 'usa-prose/src/styles/index';
-@forward './overrides';


### PR DESCRIPTION
## 🛠 Summary of changes

Regression of #390

Fixes an issue where code directly importing `usa-prose` would fail due to missing `_overrides.scss` file removed in #390.

```
Exception [Error]: Error: Can't find stylesheet to import.
  ╷
2 │ @forward './overrides';
  │ ^^^^^^^^^^^^^^^^^^^^^^
```

The project's current build pipeline would only catch errors occurring in a full build. TBD I need to more fully understand how this doesn't cause a failure within this project, but the short of it seems to be that [this file](https://github.com/18F/identity-design-system/blob/main/src/scss/packages/usa-prose/src/_styles.scss) isn't being loaded.

## 📜 Testing Plan

I reproduced the issue on `main` by testing in `identity-idp`.

In `identity-idp`:

1. Change `@18f/identity-design-system` dependency in `package.json` to point to `file:../identity-design-system`
2. `rm -rf node_modules`
3. `yarn`
4. `yarn buld:css`

Before: Fails with error mentioned above
After: Succeeds