### PR TITLE
Prepare 9.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 9.0.0
 
 ### Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "8.1.0",
+      "version": "9.0.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@types/uswds__uswds": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "The global style of Login.gov",
   "main": "./build/esm/index.js",
   "type": "module",


### PR DESCRIPTION
> ## 9.0.0
> 
> ### Breaking Changes
> 
> - [Prose](https://designsystem.digital.gov/components/prose/) styling overrides have been removed. Text formatting should now adhere to the defaults from the U.S. Web Design System. ([#390](https://github.com/18F/identity-design-system/pull/390))
> - Drop support for Internet Explorer. ([#387](https://github.com/18F/identity-style-guide/pull/387))
>    - Support was indirectly dropped in [v7.0.0](https://github.com/18F/identity-design-system/releases/tag/v7.0.0) via the upgrade to USWDS [v3.0.0](https://designsystem.digital.gov/about/releases/#version-uswds-300), which similarly ended explicit support for Internet Explorer. This package had continued to include Internet Explorer in its [Browserslist](https://browsersl.ist/) configuration, but this has now been removed.
> - Remove utility classes for raw color tokens. ([#405](https://github.com/18F/identity-style-guide/pull/405))
>    - These colors were usually incorrect because they were using U.S. Web Design System defaults instead of the Login.gov Design System color set.
>    - In most common cases, these should be replaced with stateful equivalents ("success" instead of "green") or theme colors ("base" instead of "gray-50").
>    - Applies to the following utilities:
>       - Background color (`bg-*`)
>       - Border color (`border-*`)
>       - Text color (`text-*`)
>       - Outline color (`outline-*`)
>       - Text underline color (`underline-*`)
>    - The following colors are removed:
>       - `red` (use `error` instead)
>       - `orange`
>       - `gold`
>       - `yellow` (use `warning` instead)
>       - `green` (use `success` instead)
>       - `mint`
>       - `cyan`
>       - `blue` (use `primary` instead)
>       - `indigo`
>       - `violet`
>       - `magenta`
>       - `gray-10` (use `base-lighter` instead)
>       - `gray-30` (use `base-light` instead)
>       - `gray-50` (use `base` instead)
>       - `gray-70` (use `base-darker` instead)
>       - `gray-90` (use `base-darkest` instead)
> - Remove images not integral to the design system. ([#410](https://github.com/18F/identity-design-system/pull/410))
>    - If you use any of these images, consider proposed alternatives below, or copy [the image from the previous release](https://github.com/18F/identity-design-system/tree/v8.1.2/src/img) into your project:
>       - `illustrations/fail.svg` (legacy alert icon, new alert icons will be introduced in a future release)
>       - `illustrations/security-key.svg`
>       - `angle-arrow-down-white-hover.svg` (use `expand_more` icon instead)
>       - `angle-arrow-down-white.svg` (use `expand_more` icon instead)
>       - `angle-arrow-down.svg` (use `expand_more` icon instead)
>       - `angle-arrow-up-white-hover.svg` (use `expand_less` icon instead)
>       - `angle-arrow-up-white.svg` (use `expand_less` icon instead)
>       - `angle-arrow-up.svg` (use `expand_less` icon instead)
>       - `close-primary.svg` (use `close` icon instead)
>       - `close.svg` (use `close` icon instead)
>       - `hero.png`
> - Align JavaScript component names with U.S. Web Design System. ([#414](https://github.com/18F/identity-design-system/pull/414))
>    - `header` is now named `navigation`
>    - `validation` is now named `validator`
> 
> ### Improvements
> 
> - Optimize images to reduce their size. ([#411](https://github.com/18F/identity-design-system/pull/411))
> - Browser-ready JavaScript bundles are now minified. ([#421](https://github.com/18F/identity-design-system/pull/421))
> 
> ### New Features
> 
> - Add TypeScript types for JavaScript components. ([#413](https://github.com/18F/identity-design-system/pull/413))
> - Include `init.js` as both a package entrypoint and precompiled asset within `dist/assets/js`, which provides the functionality of [U.S. Web Design System's `uswds-init.js` script](https://designsystem.digital.gov/components/banner/#using-the-banner-component-2) to reduce the appearance of flashing content during page load. See README Browser-Ready JavaScript Bundles for usage instructions. ([#421](https://github.com/18F/identity-design-system/pull/421))
> 
> ### Bug Fixes
> 
> - Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`. ([#407](https://github.com/18F/identity-design-system/pull/407))
> - Fix `dist/assets/js/main.js` compilation to properly consider browser support. ([#421](https://github.com/18F/identity-design-system/pull/421))
> - Fix strict ES Module import errors due to lack of fully-qualified file path when importing `auto` entrypoint. ([#422](https://github.com/18F/identity-design-system/pull/422))
> - Fix background color when hovering an expanded navigation section on large viewport sizes. ([#418](https://github.com/18F/identity-design-system/pull/418))
> 
> ### Internal
> 
> - Replace code compiler Babel with ESBuild. ([#387](https://github.com/18F/identity-style-guide/pull/381))
>    - This is not expected to have a downstream impact, but there may be subtle differences in the compiled code due to this change.