### PR TITLE
Fix active hover state for navigation section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`. ([#407](https://github.com/18F/identity-design-system/pull/407))
 - Fix `dist/assets/js/main.js` compilation to properly consider browser support. ([#421](https://github.com/18F/identity-design-system/pull/421))
 - Fix strict ES Module import errors due to lack of fully-qualified file path when importing `auto` entrypoint. ([#422](https://github.com/18F/identity-design-system/pull/422))
+- Fix background color when hovering an expanded navigation section on large viewport sizes. ([#418](https://github.com/18F/identity-design-system/pull/418))
 
 ### Internal
 

--- a/src/scss/packages/usa-nav/src/_overrides.scss
+++ b/src/scss/packages/usa-nav/src/_overrides.scss
@@ -42,9 +42,11 @@
     }
   }
 
-  button {
-    &:hover {
-      background-color: color('primary-lightest');
+  @include at-media-max($theme-header-min-width) {
+    button {
+      &:hover {
+        background-color: color('primary-lightest');
+      }
     }
   }
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where an expanded navigation section will show incorrectly with a light background when hovered.

See: https://github.com/18F/identity-dashboard/pull/748#issuecomment-1977518011

The background color here is meant to apply for hover states within the mobile navigation, and should not apply for larger viewport sizes. The solution is to add a media query to prevent the color from applying beyond the mobile navigation viewport width.

## 📜 Testing Plan

1. Run `npm start`
2. Go to http://localhost:4000/header/
3. Click "Section" or "Current Section" to expand navigation items
4. Keep cursor hovered over the navigation item
5. Observe that it shows correctly with a dark-blue background and white foreground text
6. In the "Mobile" preview at the bottom of the page, hover over navigation items
7. Observe that the hover background still shows as light-blue background and dark-blue foreground text

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/7e13739c-dc64-4bed-a3d4-6c0a236f2577)|![image](https://github.com/18F/identity-design-system/assets/1779930/5cfbcb97-fb4f-4361-b6c8-e9074a47c089)
