### PR TITLE
Increase viewport width for regression screenshots

### DIFF
--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -24,7 +24,12 @@ async function getScreenshot(page, url) {
 
 const esbuildContext = await esbuild.context({});
 const { port } = await esbuildContext.serve({ servedir: 'dist' });
-const browser = await puppeteer.launch();
+const browser = await puppeteer.launch({
+  defaultViewport: {
+    width: 1024,
+    height: 768,
+  },
+});
 const localURL = `http://localhost:${port}/`;
 const outputDirectory = join('tmp/screenshot/branches', branch);
 


### PR DESCRIPTION
## 🛠 Summary of changes

Increases the width for visual regression snapshots from the [default 800x600](https://pptr.dev/api/puppeteer.browserconnectoptions#properties) to 1024x768.

**Why?**

- 800x600 is a pretty non-typical size, and the updated size provides a more consistent desktop-like viewport
   - This was most noticeable in screenshots produced by #418, where the "Menu" button continues to appear until at least 1024px width. Without this change, there's some redundancy in having both the "default" and "mobile" examples, since both would show the mobile "Menu" button

## 📜 Testing Plan

1. `make build`
2. `./scripts/snapshot.js`
3. Observe that files in `tmp/screenshot/branches/aduth-visual-regression-snapshot-width` have width 1024px

## 👀 Screenshots

Using example from #418:

Before|After
---|---
![header-before](https://github.com/18F/identity-design-system/assets/1779930/ed082210-381c-42c7-9d70-42ca7176fa79)|![header-after](https://github.com/18F/identity-design-system/assets/1779930/60026cc0-15fa-43dd-ae8c-9a23edf35439)