### PR TITLE
Fix error when importing from ESM auto entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 - Add missing JavaScript exports for `button`, `inPageNavigation`, `inputMask`, `languageSelector`, and `range`. ([#407](https://github.com/18F/identity-design-system/pull/407))
 - Fix `dist/assets/js/main.js` compilation to properly consider browser support. ([#421](https://github.com/18F/identity-design-system/pull/421))
+- Fix strict ES Module import errors due to lack of fully-qualified file path when importing `auto` entrypoint. ([#422](https://github.com/18F/identity-design-system/pull/422))
 
 ### Internal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@18f/eslint-plugin-identity": "^2.0.0",
         "@18f/identity-build-sass": "^3.0.0",
         "@18f/identity-stylelint-config": "^4.0.0",
+        "@happy-dom/global-registrator": "^13.6.2",
         "@types/html_codesniffer": "^2.5.4",
         "@types/pixelmatch": "^5.2.6",
         "@types/pngjs": "^6.0.4",
@@ -721,6 +722,18 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@happy-dom/global-registrator": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-13.6.2.tgz",
+      "integrity": "sha512-kP6XjwQtYhffyapFAwTTysqc67JWSlUfK0807S84ryUxugtBxpLkDyb0tqXcAatjQFdb3Oum+xdorBR0UpT70w==",
+      "dev": true,
+      "dependencies": {
+        "happy-dom": "^13.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3380,6 +3393,29 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/happy-dom": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-13.6.2.tgz",
+      "integrity": "sha512-Ku+wDqcF/KwFA0dI+xIMZd9Jn020RXjuSil/Vz7gu2yhDC3FsDYZ55qqV9k+SGC4opwb4acisXqVSRxUJMlPbQ==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -6963,6 +6999,15 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -7559,6 +7604,15 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true
+    },
+    "@happy-dom/global-registrator": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-13.6.2.tgz",
+      "integrity": "sha512-kP6XjwQtYhffyapFAwTTysqc67JWSlUfK0807S84ryUxugtBxpLkDyb0tqXcAatjQFdb3Oum+xdorBR0UpT70w==",
+      "dev": true,
+      "requires": {
+        "happy-dom": "^13.6.2"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -9492,6 +9546,25 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "happy-dom": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-13.6.2.tgz",
+      "integrity": "sha512-Ku+wDqcF/KwFA0dI+xIMZd9Jn020RXjuSil/Vz7gu2yhDC3FsDYZ55qqV9k+SGC4opwb4acisXqVSRxUJMlPbQ==",
+      "dev": true,
+      "requires": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "dev": true
+        }
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -11929,6 +12002,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true
     },
     "whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@18f/eslint-plugin-identity": "^2.0.0",
     "@18f/identity-build-sass": "^3.0.0",
     "@18f/identity-stylelint-config": "^4.0.0",
+    "@happy-dom/global-registrator": "^13.6.2",
     "@types/html_codesniffer": "^2.5.4",
     "@types/pixelmatch": "^5.2.6",
     "@types/pngjs": "^6.0.4",

--- a/src/js/auto.js
+++ b/src/js/auto.js
@@ -1,4 +1,4 @@
-import * as components from './components';
+import * as components from './components/index.js';
 
 function initComponents() {
   const target = document.body;

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/no-unresolved */
+
+import { describe, before, after, it } from 'node:test';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+describe('imports', () => {
+  before(() => {
+    GlobalRegistrator.register();
+  });
+
+  after(() => {
+    GlobalRegistrator.unregister();
+  });
+
+  it('imports from all entrypoints without errors', async () => {
+    await Promise.all([
+      // @ts-ignore
+      import('@18f/identity-design-system'),
+      // @ts-ignore
+      import('@18f/identity-design-system/auto'),
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "module": "ESNext",
     "target": "ESNext",


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error which occurs when trying to load the `auto` entrypoint in a bundler which resolves ESM imports.

```
Module not found: Error: Can't resolve './components' in '/node_modules/@18f/identity-design-system/build/esm'
```

This is an identical issue as what was addressed in #400, but the earlier pull request only addressed the instance of the issue within `index.js`. This pull request applies the same fix to `auto.js`.

This issue was surfaced as part of ongoing work in https://github.com/18F/identity-dashboard/pull/748

## 📜 Testing Plan

Verify included test passes:

1. `make build`
2. `node --test test/imports.test.js`

Optionally, verify in an external project that you can reference `/auto`:

1. In `identity-design-system`, ensure everything is built: `make build`
2. In external project, modify `package.json` version for `@18f/identity-design-system` to point to `file:../identity-design-system` (assumes `identity-design-system` is checked out to the parent folder)
3. In external project's JavaScript entrypoint that references the `@18f/identity-design-system`, import as: `import '@18f/identity-design-system/auto';`
4. Verify you have no errors when building JavaScript