### PR TITLE
Update styling for Tag component for consistency with USWDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add SVG format option for favicon image. ([#424](https://github.com/18F/identity-design-system/pull/424))
 
+### Improvements
+
+- Update styling for Tag component for consistency with U.S. Web Design System. ([#426](https://github.com/18F/identity-design-system/pull/426))
+
 ### Dependencies
 
 - Upgrade USWDS from v3.7.1 to v3.8.0 (see [release notes](https://github.com/uswds/uswds/releases/tag/v3.8.0)) ([#425](https://github.com/18F/identity-design-system/pull/425))

--- a/src/scss/packages/usa-tag/src/_overrides.scss
+++ b/src/scss/packages/usa-tag/src/_overrides.scss
@@ -3,10 +3,8 @@
 .usa-tag {
   display: inline-block;
   font-size: units(2);
-  font-weight: bold;
   text-transform: none;
   line-height: 1.5;
-  border-radius: units(0.5);
 }
 
 .usa-tag--big {


### PR DESCRIPTION
## 🛠 Summary of changes

Removes some styling overrides from the Tag component for consistency with USWDS:

- Remove border radius override, reducing radius from 0.25rem (4px) to 0.125rem (2px)
- Remove bold styling override, reverting to normal font size

## 📜 Testing Plan

1. Run the application locally: `npm start`
2. Go to http://localhost:4000/tags/
3. Observe visual appearance of tags

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/7ea42e82-6de5-4e4c-911e-3c2fd212a3ba)|![image](https://github.com/18F/identity-design-system/assets/1779930/4a6d98ac-5200-43b8-a235-60defc9cc765)
