### PR TITLE
Remove nav container from header component example

### DIFF
--- a/docs/_components/header.md
+++ b/docs/_components/header.md
@@ -13,7 +13,7 @@ lead: >
 <div class="usa-header usa-header--extended">
   <div class="usa-navbar">
     <div class="usa-logo">
-      <a href="{{ site.baseurl }}">
+      <a href="{{ site.baseurl }}/">
         <img
           src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
           class="usa-logo__img"

--- a/docs/_components/header.md
+++ b/docs/_components/header.md
@@ -11,99 +11,97 @@ lead: >
 {% capture example %}
 <div class="usa-overlay"></div>
 <div class="usa-header usa-header--extended">
-  <div class="usa-nav-container">
-    <div class="usa-navbar">
-      <div class="usa-logo">
-        <a href="{{ site.baseurl }}">
-          <img
-            src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
-            class="usa-logo__img"
-            alt="Login.gov Homepage"
-            width="179"
-            height="24"
-          />
-        </a>
-      </div>
-
-      <button class="usa-menu-btn">Menu</button>
+  <div class="usa-navbar">
+    <div class="usa-logo">
+      <a href="{{ site.baseurl }}">
+        <img
+          src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
+          class="usa-logo__img"
+          alt="Login.gov Homepage"
+          width="179"
+          height="24"
+        />
+      </a>
     </div>
 
-    <nav class="usa-nav" aria-label="Primary links">
-      <div class="usa-nav__inner">
-        <button class="usa-nav__close" aria-label="Close">
-          <svg class="usa-icon usa-icon--size-3" aria-hidden="true" role="img">
-            <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#close"></use>
-          </svg>
-        </button>
-        <ul class="usa-nav__primary usa-accordion">
-          <li class="usa-nav__primary-item">
-            <a class="usa-nav__link" href="{{ site.baseurl }}">
-              Navigation Link
-            </a>
-          </li>
-          <li class="usa-nav__primary-item">
-            <a class="usa-nav__link usa-current" href="{{ site.baseurl }}">
-              Current Navigation Link
-            </a>
-          </li>
-          <li class="usa-nav__primary-item">
-            <button
-              type="button"
-              class="usa-accordion__button usa-nav__link"
-              aria-expanded="false"
-              aria-controls="nav-section"
-            >
-              <span>Section</span>
-            </button>
-            <ul id="nav-section" class="usa-nav__submenu">
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="usa-nav__primary-item">
-            <button
-              type="button"
-              class="usa-accordion__button usa-nav__link usa-current"
-              aria-expanded="false"
-              aria-controls="current-nav-section"
-            >
-              <span>Current Section</span>
-            </button>
-            <ul id="current-nav-section" class="usa-nav__submenu">
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-              <li class="usa-nav__submenu-item">
-                <a href="{{ site.baseurl }}">
-                  <span>Navigation Link</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </nav>
+    <button class="usa-menu-btn">Menu</button>
   </div>
+
+  <nav class="usa-nav" aria-label="Primary links">
+    <div class="usa-nav__inner">
+      <button class="usa-nav__close" aria-label="Close">
+        <svg class="usa-icon usa-icon--size-3" aria-hidden="true" role="img">
+          <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#close"></use>
+        </svg>
+      </button>
+      <ul class="usa-nav__primary usa-accordion">
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="{{ site.baseurl }}">
+            Navigation Link
+          </a>
+        </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link usa-current" href="{{ site.baseurl }}">
+            Current Navigation Link
+          </a>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button
+            type="button"
+            class="usa-accordion__button usa-nav__link"
+            aria-expanded="false"
+            aria-controls="nav-section"
+          >
+            <span>Section</span>
+          </button>
+          <ul id="nav-section" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button
+            type="button"
+            class="usa-accordion__button usa-nav__link usa-current"
+            aria-expanded="false"
+            aria-controls="current-nav-section"
+          >
+            <span>Current Section</span>
+          </button>
+          <ul id="current-nav-section" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="{{ site.baseurl }}">
+                <span>Navigation Link</span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </div>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}


### PR DESCRIPTION
## 🛠 Summary of changes

Improves header component markup example to avoid `<div class="usa-nav-container">`. It also updates the logo link to always point to the root regardless of `{{ site.baseurl }}` value (previously it would often link to the same page).

**Why?**

- This markup was originally sourced from `identity-site`, but the [default USWDS component guidance](https://designsystem.digital.gov/components/header/) for extended header does not include it
- The `usa-nav-container` creates additional horizontal padding that causes it to be misaligned with page content that includes navigation

## 📜 Testing Plan

Easiest to review with whitespace changes hidden, since the changes amount to removing a single wrapper element `<div class="usa-nav-container">`.

1. `npm start`
2. Visit http://localhost:4000/banner/
3. Observe reduced horizontal padding on header

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/8f35c97c-c67f-4a63-ae63-4743851e22fe)|![image](https://github.com/18F/identity-design-system/assets/1779930/bcd668ee-1348-4403-8916-79ed529ca858)
