### PR TITLE
Add banner and header with navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ keep_files:
 collections:
   components:
     output: true
+    show_in_navigation: true
     permalink: /:name/
   embeds:
     output: true

--- a/docs/_includes/banner.html
+++ b/docs/_includes/banner.html
@@ -1,0 +1,74 @@
+<section
+  class="usa-banner"
+  aria-label="Official website of the United States government"
+>
+  <div class="usa-accordion">
+    <header class="usa-banner__header">
+      <div class="usa-banner__inner">
+        <div class="grid-col-auto">
+          <img
+            aria-hidden="true"
+            class="usa-banner__header-flag"
+            width="16"
+            height="11"
+            src="{{ site.baseurl }}/assets/img/us_flag.svg"
+            alt=""
+          />
+        </div>
+        <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
+          <p class="usa-banner__header-text">
+            An official website of the United States government
+          </p>
+          <p class="usa-banner__header-action">Here’s how you know</p>
+        </div>
+        <button
+          type="button"
+          class="usa-accordion__button usa-banner__button"
+          aria-expanded="false"
+          aria-controls="gov-banner"
+        >
+          <span class="usa-banner__button-text">Here’s how you know</span>
+        </button>
+      </div>
+    </header>
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="grid-row grid-gap-lg">
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong><br />A
+              <strong>.gov</strong> website belongs to an official government
+              organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="{{ site.baseurl }}/assets/img/icon-https.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong><br />
+              A <strong>lock</strong> (
+              <img src="{{ site.baseurl }}/assets/img/lock.svg" alt="Locked padlock icon" height="12" width="9" class="usa-banner__lock-image">
+              ) or <strong>https://</strong> means you’ve safely connected to
+              the .gov website. Share sensitive information only on official,
+              secure websites.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,0 +1,41 @@
+<div class="usa-overlay"></div>
+<div class="usa-header usa-header--extended">
+  <div class="usa-navbar">
+    <div class="usa-logo">
+      <a href="{{ site.baseurl }}/">
+        <img
+          src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
+          class="usa-logo__img"
+          alt="Login.gov Homepage"
+          width="179"
+          height="24"
+        />
+      </a>
+    </div>
+
+    <button class="usa-menu-btn">Menu</button>
+  </div>
+
+  <nav class="usa-nav" aria-label="Primary links">
+    <div class="usa-nav__inner">
+      <button class="usa-nav__close" aria-label="Close">
+        <svg class="usa-icon usa-icon--size-3" aria-hidden="true" role="img">
+          <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#close"></use>
+        </svg>
+      </button>
+      <ul class="usa-nav__primary usa-accordion">
+        {% assign navigation_collections = site.collections | where: 'show_in_navigation', true %}
+        {% for collection in navigation_collections %}
+          <li class="usa-nav__primary-item">
+            <a
+              href="{{ site[collection.label][0].url }}"
+              class="usa-nav__link {% if page.collection == collection.label %}usa-current{% endif %}"
+            >
+              {{ collection.label | capitalize }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </nav>
+</div>

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -8,6 +8,8 @@
     <script src="{{ site.baseurl }}/assets/js/init.js"></script>
   </head>
   <body>
+    {% include banner.html %}
+    {% include header.html %}
     {{ content }}
     <script src="{{ site.baseurl }}/assets/js/main.js"></script>
   </body>

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -8,8 +8,6 @@
     <script src="{{ site.baseurl }}/assets/js/init.js"></script>
   </head>
   <body>
-    {% include banner.html %}
-    {% include header.html %}
     {{ content }}
     <script src="{{ site.baseurl }}/assets/js/main.js"></script>
   </body>

--- a/docs/_layouts/component.html
+++ b/docs/_layouts/component.html
@@ -2,6 +2,9 @@
 layout: base
 ---
 
+{% include banner.html %}
+{% include header.html %}
+
 <main class="padding-y-4">
   <div class="grid-container">
     <div class="grid-row grid-gap">


### PR DESCRIPTION
## 🛠 Summary of changes

Adds banner, header, and primary navigation to the local documentation site.

**Why?**

- "Dogfooding" our own components helps surface potential issues with documented usage (see #429 and #430 as examples)
   - This also opens the possibility of internally reusing "includes" for header with documented usage for guaranteed one-to-one documentation and usage
- This is part of a series of changes looking to introduce new sections for "Utilities" in addition to components, which will be included in the primary navigation.

## 📜 Testing Plan

1. Go to http://localhost:4000
2. Observe banner, header, and primary navigation

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/01ed2ffc-2d5b-4907-8850-d7848f338623)|![image](https://github.com/18F/identity-design-system/assets/1779930/4ee05748-d3c5-4ba0-8f50-acde045eb4c2)
