### PR TITLE
Hide collapsed Accordion component content while JavaScript loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
 
 - Update styling for Tag component for consistency with U.S. Web Design System. ([#426](https://github.com/18F/identity-design-system/pull/426))
+- Hide collapsed Accordion component content while JavaScript loads. ([#434](https://github.com/18F/identity-design-system/pull/434))
 
 ### Dependencies
 

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -8,40 +8,62 @@ lead: >
 
 Before using an accordion, consider if their use would hinder usability. If there is not enough content to warrant condensing or if visitors need to see most or all of the information on a page, use well-formatted text instead.
 
+In the examples below, replace `<h2>` with the appropriate heading level to maintain the document's outline.
+
+## Default
+
 {% capture example %}
-<div class="usa-accordion usa-accordion--bordered" data-test="accordion">
-  <!-- Use the accurate heading level to maintain the document outline -->
+<div class="usa-accordion">
   <h2 class="usa-accordion__heading">
     <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-1">
       How do I make an accordion’s content shown by default?
     </button>
   </h2>
-  <div id="unique-id-1" class="usa-accordion__container">
-    <div class="usa-accordion__content usa-prose">
-      <p>Follow this example! Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="true"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is expanded by default, and omit the <code>hidden</code> attribute on the related <code>.usa-accordion__content</code>.</p>
-    </div>
+  <div id="unique-id-1" class="usa-accordion__content usa-prose">
+    <p>Follow this example! Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="true"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is expanded by default.</p>
   </div>
 
   <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-controls="unique-id-2">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-2">
       How do I make an accordion’s content hidden by default?
     </button>
   </h2>
-  <div id="unique-id-2" class="usa-accordion__container">
-    <div class="usa-accordion__content usa-prose">
-      <p>Do not mark any attributes, other than linking a header and content body by <code>aria-controls="unique-id"</code> and <code>id="unique-id"</code>. This ensures the content is accessible should JavaScript fail to load.</p>
-    </div>
+  <div id="unique-id-2" class="usa-accordion__content usa-prose">
+    <p>Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="false"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is collapsed by default.</p>
   </div>
 
   <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-controls="unique-id-3">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-3">
       How can I allow more than one accordion item to be open simultaneously?
     </button>
   </h2>
-  <div id="unique-id-3" class="usa-accordion__container">
-    <div class="usa-accordion__content usa-prose">
-      <p>On the wrapping <code>.usa-accordion</code>, add the <code>aria-multiselectable="true"</code> attribute.</p>
-    </div>
+  <div id="unique-id-3" class="usa-accordion__content usa-prose">
+    <p>On the wrapping <code>.usa-accordion</code>, add the <code>aria-multiselectable="true"</code> attribute.</p>
+  </div>
+</div>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
+## Bordered
+
+{% capture example %}
+<div class="usa-accordion usa-accordion--bordered">
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-4">
+      First Amendment
+    </button>
+  </h2>
+  <div id="unique-id-4" class="usa-accordion__content usa-prose">
+    <p>Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.</p>
+  </div>
+
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-5">
+      Second Amendment
+    </button>
+  </h2>
+  <div id="unique-id-5" class="usa-accordion__content usa-prose">
+    <p>A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</p>
   </div>
 </div>
 {% endcapture %}

--- a/docs/_components/validation.md
+++ b/docs/_components/validation.md
@@ -40,15 +40,13 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
       Textarea (multiline) input
     </button>
   </h3>
-  <div id="errored-textarea" class="usa-accordion__container">
-    <div class="usa-accordion__content">
+  <div id="errored-textarea" class="usa-accordion__content">
 {% capture example %}
 <label for="a37c" class="usa-label">Textarea (multiline) input</label>
 <textarea id="a37c" type="text" class="usa-textarea usa-input--error"></textarea>
 <span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
-    </div>
   </div>
 
   <h3 class="usa-accordion__heading">
@@ -56,8 +54,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
       Dates
     </button>
   </h3>
-  <div id="errored-dates" class="usa-accordion__container">
-    <div class="usa-accordion__content">
+  <div id="errored-dates" class="usa-accordion__content">
 {% capture example %}
 
 <fieldset class="usa-fieldset">
@@ -115,7 +112,6 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
 </fieldset>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
-    </div>
   </div>
 
   <h3 class="usa-accordion__heading">
@@ -123,8 +119,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
       Dropdowns
     </button>
   </h3>
-  <div id="errored-dropdowns" class="usa-accordion__container">
-    <div class="usa-accordion__content">
+  <div id="errored-dropdowns" class="usa-accordion__content">
 {% capture example %}
 <label for="d8e1" class="usa-label">Dropdown label</label>
 <select id="d8e1" class="usa-select usa-input--error">
@@ -136,7 +131,6 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
 <span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
-    </div>
   </div>
 </div>
 
@@ -150,8 +144,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
       Radio buttons
     </button>
   </h3>
-  <div id="errored-radio-small" class="usa-accordion__container">
-    <div class="usa-accordion__content">
+  <div id="errored-radio-small" class="usa-accordion__content">
 {% capture example %}
 <fieldset class="usa-fieldset">
   <legend class="usa-legend">Group label</legend>
@@ -173,7 +166,6 @@ For radio buttons and checkboxes, simply add an error message directly after the
 <span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
-    </div>
   </div>
 
   <h3 class="usa-accordion__heading">
@@ -181,8 +173,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
       Checkboxes
     </button>
   </h3>
-  <div id="errored-checkbox-small" class="usa-accordion__container">
-    <div class="usa-accordion__content">
+  <div id="errored-checkbox-small" class="usa-accordion__content">
 {% capture example %}
 <fieldset class="usa-fieldset">
   <legend class="usa-legend">Group label</legend>
@@ -204,6 +195,5 @@ For radio buttons and checkboxes, simply add an error message directly after the
 <span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
-    </div>
   </div>
 </div>

--- a/docs/_includes/helpers/code-example.html
+++ b/docs/_includes/helpers/code-example.html
@@ -6,6 +6,6 @@
 
 <div markdown="1">
 ```html
-{{ include.code | replace: site.baseurl, '' | strip | replace_regex: '\s?data-test(?:="[^\s"]+")', '' }}
+{{ include.code | replace: site.baseurl, '' | strip }}
 ```
 </div>

--- a/src/js/init.ts
+++ b/src/js/init.ts
@@ -1,4 +1,2 @@
 document.documentElement.classList.add('usa-js-loading');
-addEventListener('load', () => {
-  document.documentElement.classList.remove('usa-js-loading');
-});
+addEventListener('load', () => document.documentElement.classList.remove('usa-js-loading'));

--- a/src/scss/packages/usa-accordion/src/_overrides.scss
+++ b/src/scss/packages/usa-accordion/src/_overrides.scss
@@ -43,3 +43,15 @@
     @include u-radius-bottom('lg');
   }
 }
+
+// Upstream: https://github.com/uswds/uswds/pull/5826
+.usa-js-loading {
+  .usa-accordion {
+    .usa-accordion__heading:has(.usa-accordion__button:not([aria-expanded='true'])),
+    .usa-accordion__button:not([aria-expanded='true']) {
+      & + .usa-accordion__content {
+        @include add-sr-only;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🛠 Summary of changes

This enhances accordion styles to appear hidden while JavaScript is loaded if expected to be collapsed once JavaScript finishes loading, avoiding the appearance of flashing content.

This backports changes added to the brochure site in https://github.com/GSA-TTS/identity-site/pull/1224

It also incorporates a number of improvements:

- Fixes an issue with https://github.com/GSA-TTS/identity-site/pull/1224 where it would not apply to sibling content of accordions where the button is wrapped inside a header container
- Inverts the selector to look for `:not([aria-expanded='true'])` instead of `[aria-expanded='false']` to support expected behavior where the `aria-expanded` attribute is not explicitly specified
- Updates component examples for Accordion:
   - Document differences between "Default" and "Bordered" variant options
   - Remove an unnecessary and useless `usa-accordion__container` container element which is not standard to USWDS and would make the JavaScript hiding behavior ineffective
   - Remove unused and unnecessary `data-test` attribute
   - Encourage use of explicit `aria-expanded="false"`
- Micro-optimizes `src/js/init.ts` to remove unnecessary curly braces on function body, syncing with upstream https://github.com/uswds/uswds/pull/5819

## 📜 Testing Plan

1. `npm start`
2. Visit http://localhost:4000/accordions/
3. Hard refresh
4. Observe no flashing content
5. Observe documented examples for "Default" and "Bordered" appear without and with borders respectively