### PR TITLE
Use frame for sandboxed component preview, stricter accessibility checks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,3 +21,7 @@ defaults:
       path: ''
     values:
       layout: two_column
+  - scope:
+      type: embeds
+    values:
+      layout: embed

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -16,25 +16,4 @@ In the examples below, replace `<h2>` with the appropriate heading level to main
 
 ## Bordered
 
-{% capture example %}
-<div class="usa-accordion usa-accordion--bordered">
-  <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-4">
-      First Amendment
-    </button>
-  </h2>
-  <div id="unique-id-4" class="usa-accordion__content usa-prose">
-    <p>Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.</p>
-  </div>
-
-  <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-5">
-      Second Amendment
-    </button>
-  </h2>
-  <div id="unique-id-5" class="usa-accordion__content usa-prose">
-    <p>A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="accordions/bordered" %}

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -12,37 +12,7 @@ In the examples below, replace `<h2>` with the appropriate heading level to main
 
 ## Default
 
-{% capture example %}
-<div class="usa-accordion">
-  <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-1">
-      How do I make an accordion’s content shown by default?
-    </button>
-  </h2>
-  <div id="unique-id-1" class="usa-accordion__content usa-prose">
-    <p>Follow this example! Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="true"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is expanded by default.</p>
-  </div>
-
-  <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-2">
-      How do I make an accordion’s content hidden by default?
-    </button>
-  </h2>
-  <div id="unique-id-2" class="usa-accordion__content usa-prose">
-    <p>Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="false"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is collapsed by default.</p>
-  </div>
-
-  <h2 class="usa-accordion__heading">
-    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-3">
-      How can I allow more than one accordion item to be open simultaneously?
-    </button>
-  </h2>
-  <div id="unique-id-3" class="usa-accordion__content usa-prose">
-    <p>On the wrapping <code>.usa-accordion</code>, add the <code>aria-multiselectable="true"</code> attribute.</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="accordions/default" %}
 
 ## Bordered
 

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -21,55 +21,20 @@ Visit the [USWDS Alerts component](https://designsystem.digital.gov/components/a
 
 ### Success
 
-{% capture example %}
-<div class="usa-alert usa-alert--success">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Banner text</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="alerts/success" %}
 
 ### Warning
 
-{% capture example %}
-<div class="usa-alert usa-alert--warning">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Banner text</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="alerts/warning" %}
 
 ### Error
 
-{% capture example %}
-<div class="usa-alert usa-alert--error">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Banner text</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="alerts/error" %}
 
 ### Information
 
-{% capture example %}
-<div class="usa-alert usa-alert--info">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Banner text</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="alerts/info" %}
 
 ### Other
 
-{% capture example %}
-<div class="usa-alert usa-alert--other">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Banner text</p>
-  </div>
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="alerts/other" %}

--- a/docs/_components/badges.md
+++ b/docs/_components/badges.md
@@ -12,22 +12,10 @@ Badges are comprised with a div using the `lg-verification-badge` class and a sm
 
 The unphishable badge is used to indicate that an account is only using security keys as its MFA method.
 
-{% capture example %}
-<div class="lg-verification-badge">
-  <img src="{{ site.baseurl }}/assets/img/alerts/unphishable.svg" role="img" width="16" height="16" alt="" />
-  Unphishable
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="badges/unphishable" %}
 
 ## A verified account badge example
 
 A verfied account badge is used to indicate that an account has completed the identity verification process.
 
-{% capture example %}
-<div class="lg-verification-badge">
-  <img src="{{ site.baseurl }}/assets/img/alerts/success.svg" role="img" width="16" height="16" alt="" />
-  Verified Account
-</div>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="badges/verified-account" %}

--- a/docs/_components/banner.md
+++ b/docs/_components/banner.md
@@ -7,14 +7,8 @@ lead: Banners identify official websites of government organizations in the Unit
 
 ## Default
 
-{% capture example %}
-{% include banner.html id="gov-banner-default" %}
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="banner/default" %}
 
 ## Centered
 
-{% capture example %}
-{% include banner.html centered=true id="gov-banner-centered" %}
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="banner/centered" %}

--- a/docs/_components/button-groups.md
+++ b/docs/_components/button-groups.md
@@ -8,34 +8,8 @@ title: Button Groups
 
 ### Default
 
-{% capture example %}
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button usa-button--outline">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button usa-button--outline">Button</button>
-  </li>
-</ul>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="button-groups/default-segmented" %}
 
 ### Big
 
-{% capture example %}
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button usa-button--big">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
-  </li>
-</ul>
-{% endcapture %}
-{% include helpers/code-example.html code=example %}
+{% include helpers/embed.html embed="button-groups/big-segmented" %}

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -17,17 +17,7 @@ subnav:
 
 ### Primary
 
-```html
-<button class="usa-button">
-```
-
-<div>
-  <button class="usa-button">Default</button>
-  <button class="usa-button usa-button--hover">Hover</button>
-  <button class="usa-button usa-button--active">Active</button>
-  <button class="usa-button usa-focus">Focus</button>
-  <button class="usa-button" disabled>Disabled</button>
-</div>
+{% include helpers/embed.html embed="buttons/default-primary" %}
 
 ### Outline
 

--- a/docs/_embeds/accordions/bordered.md
+++ b/docs/_embeds/accordions/bordered.md
@@ -1,0 +1,23 @@
+---
+title: Bordered Accordion
+---
+
+<div class="usa-accordion usa-accordion--bordered">
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-4">
+      First Amendment
+    </button>
+  </h2>
+  <div id="unique-id-4" class="usa-accordion__content usa-prose">
+    <p>Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.</p>
+  </div>
+
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-5">
+      Second Amendment
+    </button>
+  </h2>
+  <div id="unique-id-5" class="usa-accordion__content usa-prose">
+    <p>A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</p>
+  </div>
+</div>

--- a/docs/_embeds/accordions/default.md
+++ b/docs/_embeds/accordions/default.md
@@ -1,0 +1,32 @@
+---
+title: Default Accordion
+---
+
+<div class="usa-accordion">
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="true" aria-controls="unique-id-1">
+      How do I make an accordion’s content shown by default?
+    </button>
+  </h2>
+  <div id="unique-id-1" class="usa-accordion__content usa-prose">
+    <p>Follow this example! Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="true"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is expanded by default.</p>
+  </div>
+
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-2">
+      How do I make an accordion’s content hidden by default?
+    </button>
+  </h2>
+  <div id="unique-id-2" class="usa-accordion__content usa-prose">
+    <p>Mark the <code>.usa-accordion__button</code> with <code>aria-expanded="false"</code> to indicate that the content referenced with the ID listed in <code>aria-controls</code> is collapsed by default.</p>
+  </div>
+
+  <h2 class="usa-accordion__heading">
+    <button class="usa-accordion__button" aria-expanded="false" aria-controls="unique-id-3">
+      How can I allow more than one accordion item to be open simultaneously?
+    </button>
+  </h2>
+  <div id="unique-id-3" class="usa-accordion__content usa-prose">
+    <p>On the wrapping <code>.usa-accordion</code>, add the <code>aria-multiselectable="true"</code> attribute.</p>
+  </div>
+</div>

--- a/docs/_embeds/alerts/error.md
+++ b/docs/_embeds/alerts/error.md
@@ -1,0 +1,9 @@
+---
+title: Error Alert
+---
+
+<div class="usa-alert usa-alert--error">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Banner text</p>
+  </div>
+</div>

--- a/docs/_embeds/alerts/info.md
+++ b/docs/_embeds/alerts/info.md
@@ -1,0 +1,9 @@
+---
+title: Info Alert
+---
+
+<div class="usa-alert usa-alert--info">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Banner text</p>
+  </div>
+</div>

--- a/docs/_embeds/alerts/other.md
+++ b/docs/_embeds/alerts/other.md
@@ -1,0 +1,9 @@
+---
+title: Other Alert
+---
+
+<div class="usa-alert usa-alert--other">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Banner text</p>
+  </div>
+</div>

--- a/docs/_embeds/alerts/success.md
+++ b/docs/_embeds/alerts/success.md
@@ -1,0 +1,9 @@
+---
+title: Success Alert
+---
+
+<div class="usa-alert usa-alert--success">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Banner text</p>
+  </div>
+</div>

--- a/docs/_embeds/alerts/warning.md
+++ b/docs/_embeds/alerts/warning.md
@@ -1,0 +1,9 @@
+---
+title: Warning Alert
+---
+
+<div class="usa-alert usa-alert--warning">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Banner text</p>
+  </div>
+</div>

--- a/docs/_embeds/badges/unphishable.md
+++ b/docs/_embeds/badges/unphishable.md
@@ -1,0 +1,8 @@
+---
+title: Unphishable Badge
+---
+
+<div class="lg-verification-badge">
+  <img src="{{ site.baseurl }}/assets/img/alerts/unphishable.svg" role="img" width="16" height="16" alt="" />
+  Unphishable
+</div>

--- a/docs/_embeds/badges/verified-account.md
+++ b/docs/_embeds/badges/verified-account.md
@@ -1,0 +1,8 @@
+---
+title: Verified Account Badge
+---
+
+<div class="lg-verification-badge">
+  <img src="{{ site.baseurl }}/assets/img/alerts/success.svg" role="img" width="16" height="16" alt="" />
+  Verified Account
+</div>

--- a/docs/_embeds/banner/centered.md
+++ b/docs/_embeds/banner/centered.md
@@ -1,0 +1,5 @@
+---
+title: Centered Banner
+---
+
+{% include banner.html centered=true id="gov-banner-centered" %}

--- a/docs/_embeds/banner/default.md
+++ b/docs/_embeds/banner/default.md
@@ -1,0 +1,5 @@
+---
+title: Default Banner
+---
+
+{% include banner.html id="gov-banner-default" %}

--- a/docs/_embeds/button-groups/big-segmented.md
+++ b/docs/_embeds/button-groups/big-segmented.md
@@ -1,0 +1,15 @@
+---
+title: Big Segmented Button Group
+---
+
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--big usa-button--outline">Button</button>
+  </li>
+</ul>

--- a/docs/_embeds/button-groups/default-segmented.md
+++ b/docs/_embeds/button-groups/default-segmented.md
@@ -1,0 +1,15 @@
+---
+title: Default Segmented Button Group
+---
+
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button</button>
+  </li>
+</ul>

--- a/docs/_embeds/buttons/default-primary.md
+++ b/docs/_embeds/buttons/default-primary.md
@@ -1,0 +1,11 @@
+---
+title: Default Primary Buttons
+---
+
+<div>
+  <button class="usa-button">Default</button>
+  <button class="usa-button usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--active">Active</button>
+  <button class="usa-button usa-focus">Focus</button>
+  <button class="usa-button" disabled>Disabled</button>
+</div>

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -12,7 +12,7 @@
   width="100%"
   height="400"
   frameborder="0"
-  class="display-block margin-y-3"
+  class="display-block margin-y-2"
 ></iframe>
 <script>
   (() => {

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -12,6 +12,7 @@
   width="100%"
   height="400"
   frameborder="0"
+  class="margin-y-3"
 ></iframe>
 <script>
   /** @type {HTMLIFrameElement} */

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -12,7 +12,7 @@
   width="100%"
   height="400"
   frameborder="0"
-  class="margin-y-3"
+  class="margin-top-3"
 ></iframe>
 <script>
   /** @type {HTMLIFrameElement} */

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -15,16 +15,18 @@
   class="display-block margin-y-3"
 ></iframe>
 <script>
-  /** @type {HTMLIFrameElement} */
-  const iframe = document.currentScript.previousElementSibling;
-  window.addEventListener('message', (event) => {
-    if (event.origin !== window.location.origin || event.source !== iframe.contentWindow) {
-      return;
-    }
+  (() => {
+    /** @type {HTMLIFrameElement} */
+    const iframe = document.currentScript.previousElementSibling;
+    window.addEventListener('message', (event) => {
+      if (event.origin !== window.location.origin || event.source !== iframe.contentWindow) {
+        return;
+      }
 
-    const height = Number(event.data);
-    iframe.height = height;
-  });
+      const height = Number(event.data);
+      iframe.height = height;
+    });
+  })();
 </script>
 
 <div markdown="1">

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -1,0 +1,33 @@
+{% assign include_path = include.embed | prepend: '_embeds/' | append: '.md' %}
+{% for embed in site.embeds %}
+  {% if embed.path == include_path %}
+    {% assign embed_code = embed.content %}
+    {% assign embed_title = embed.title %}
+  {% endif %}
+{% endfor %}
+
+<iframe
+  title="{{ embed_title | default: 'Component Preview' }}"
+  src="{{ site.baseurl }}/embeds/{{ include.embed }}"
+  width="100%"
+  height="400"
+  frameborder="0"
+></iframe>
+<script>
+  /** @type {HTMLIFrameElement} */
+  const iframe = document.currentScript.previousElementSibling;
+  window.addEventListener('message', (event) => {
+    if (event.origin !== window.location.origin || event.source !== iframe.contentWindow) {
+      return;
+    }
+
+    const height = Number(event.data);
+    iframe.height = height;
+  });
+</script>
+
+<div markdown="1">
+```html
+{{ embed_code | replace: site.baseurl, '' | strip }}
+```
+</div>

--- a/docs/_includes/helpers/embed.html
+++ b/docs/_includes/helpers/embed.html
@@ -12,7 +12,7 @@
   width="100%"
   height="400"
   frameborder="0"
-  class="margin-top-3"
+  class="display-block margin-y-3"
 ></iframe>
 <script>
   /** @type {HTMLIFrameElement} */

--- a/docs/_layouts/embed.html
+++ b/docs/_layouts/embed.html
@@ -1,0 +1,15 @@
+---
+layout: base
+---
+
+{{ content }}
+
+<script>
+  function sendHeight() {
+    const { offsetHeight: height } = document.body;
+    window.parent?.postMessage(height, window.location.origin);
+  }
+
+  sendHeight();
+  new ResizeObserver(sendHeight).observe(document.body);
+</script>

--- a/docs/_layouts/embed.html
+++ b/docs/_layouts/embed.html
@@ -2,7 +2,9 @@
 layout: base
 ---
 
-{{ content }}
+<div class="padding-y-1">
+  {{ content }}
+</div>
 
 <script>
   function sendHeight() {

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -36,7 +36,9 @@ describe('accessibility', () => {
     test(path, async () => {
       const page = await browser.newPage();
       await page.goto(`http://localhost:${port}${path}`);
-      const results = await new AxePuppeteer(page).withTags(['wcag2a', 'wcag2aa']).analyze();
+      const results = await new AxePuppeteer(page)
+        .withTags(['wcag2a', 'wcag2aa', 'best-practice'])
+        .analyze();
       await page.close();
 
       assert.deepStrictEqual(results.violations, []);


### PR DESCRIPTION
## 🛠 Summary of changes

Adapts component previews to use an isolated preview sandbox using `iframe` elements.

The intent is to be able to enable stricter automated accessibility tests, which were previously not possible and [identified as a follow-up goal](https://github.com/18F/identity-design-system/pull/435#discussion_r1532727802) due to the fact that previews _assume_ an isolated render environment, but didn't _actually_ isolate.

This is similar to #418 and adapts some of the `postMessage`-based frame communication, though in a much more limited capacity, as the frame content itself is generated statically by Jekyll, and the only frame communication is necessary to resize the preview on content changes.

**Draft:** Currently, proof-of-concept only adapts the Accordion Default preview.

## 📜 Testing Plan

Verify there is no detectable difference in the preview of a component, e.g. the Accordions Default preview.

## 👀 Screenshots

![Screenshot 2024-04-19 at 11 39 30 AM](https://github.com/18F/identity-design-system/assets/1779930/52d6df50-0f51-4d3a-b4dc-07f2cfb1dce4)