### PR TITLE
Assign script output name in ESBuild command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "./build/*/init.js"
   ],
   "scripts": {
-    "build:js": "esbuild src/js/auto.js src/js/init.ts --bundle --minify --outdir=dist/assets/js --target=`./scripts/esbuild-targets.mjs`",
-    "postbuild:js": "mv dist/assets/js/auto.js dist/assets/js/main.js",
+    "build:js": "esbuild main=src/js/auto.js src/js/init.ts --bundle --minify --outdir=dist/assets/js --target=`./scripts/esbuild-targets.mjs`",
     "build:css": "build-sass src/scss/*.scss --load-path=./src/scss/packages --out-dir=dist/assets/css",
     "build:docs:css": "npm run build:css --",
     "build:docs:js": "npm run build:js --",


### PR DESCRIPTION
## 🛠 Summary of changes

Updates JavaScript build script to perform the rename of `auto.js` source script to `main.js` dist script as part of the ESBuild command itself, using [custom output path support](https://esbuild.github.io/api/#entry-points:~:text=In%20addition%2C%20you%20can%20also%20specify%20a,Go).

This is both simpler, and will hopefully address some inconsistent issues where the post-build script isn't always run as expected, resulting in a scenario where `main.js` 404s.

## 📜 Testing Plan

1. `npm start`
2. Visit http://localhost:4000
3. Observe no errors in the developer tools console, and script loading works as expected (e.g. banner is not expanded by default)