### PR TITLE
Improve compatibility/precision for badge styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Breaking Changes
+
+- Remove support for deprecation notices in v9.2.0:
+  - Badge component markup has been updated. ([#442](https://github.com/18F/identity-design-system/pull/442))
+
 ### Dependencies
 
 - Upgrade USWDS from v3.8.0 to v3.8.1 (see [release notes](https://github.com/uswds/uswds/releases/tag/v3.8.1)) ([#448](https://github.com/18F/identity-design-system/pull/448))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## Unreleased
 
-### Breaking Changes
+### Bug Fixes
 
-- Remove support for deprecation notices in v9.2.0:
-  - Badge component markup has been updated. ([#442](https://github.com/18F/identity-design-system/pull/442))
+- Improve compatibility of badge icon styling for inner Icon component. ([#445](https://github.com/18F/identity-design-system/pull/445))
 
 ### Dependencies
 

--- a/src/scss/packages/usa-verification-badge/src/_styles.scss
+++ b/src/scss/packages/usa-verification-badge/src/_styles.scss
@@ -10,8 +10,7 @@
   padding: units(1) units(2);
   white-space: nowrap;
 
-  img, // BREAKING: Remove `img` in next major release
-  svg {
+  .usa-icon {
     margin-right: units(1);
   }
 }

--- a/src/scss/packages/usa-verification-badge/src/_styles.scss
+++ b/src/scss/packages/usa-verification-badge/src/_styles.scss
@@ -10,6 +10,7 @@
   padding: units(1) units(2);
   white-space: nowrap;
 
+  img, // BREAKING: Remove `img` in next major release
   .usa-icon {
     margin-right: units(1);
   }


### PR DESCRIPTION
## 🛠 Summary of changes

Iterates on styles introduced in #442 targeting the badge icon.

The IdP has a [novel implementation](https://github.com/18F/identity-idp/pull/10065) of icon component which does not render markup as an `<svg />` element, but _does_ implement the equivalent as with the `usa-icon` class. Since it would be preferable (more precise) to implement the class selector vs. an element selector, this improves compatibility as well as improving the general implementation.

As part of the changes here, I dropped the selector which was deprecated as part of the work in #442, with the expectation this can be included in the next major release.

A patch release is not planned, and a temporary workaround will be added to the IdP instead.

## 📜 Testing Plan

Repeat testing plan from #442.

## 👀 Screenshots

There is not expected to be any visual impact of these changes, to be validated by the visual regression specs.