### PR TITLE
Update default alert styles to replace "Other" variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Improvements
+
+- Update styling for Default (previously "Other") Alert component variant, for greater distinction from other variants and consistency with U.S. Web Design System. ([#449](https://github.com/18F/identity-design-system/pull/449))
+  - It is no longer necessary to assign the `usa-alert--other` class to use these styles, and it can be safely removed. Existing code assigning `usa-alert--other` should continue to display the updated default styles as expected.
+
 ### Bug Fixes
 
 - Improve compatibility of badge icon styling for inner Icon component. ([#445](https://github.com/18F/identity-design-system/pull/445))

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -63,10 +63,10 @@ Visit the [USWDS Alerts component](https://designsystem.digital.gov/components/a
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
 
-### Other
+### Default
 
 {% capture example %}
-<div class="usa-alert usa-alert--other">
+<div class="usa-alert">
   <div class="usa-alert__body">
     <p class="usa-alert__text">Banner text</p>
   </div>

--- a/src/scss/packages/usa-alert/src/_overrides.scss
+++ b/src/scss/packages/usa-alert/src/_overrides.scss
@@ -10,22 +10,16 @@ $alerts: 'success', 'warning', 'error', 'info', 'emergency';
 
   .usa-alert__body {
     @include u-padding-x($theme-alert-padding-x); // See: https://github.com/uswds/uswds/issues/5252
-    padding-left: units($theme-alert-icon-size) + (1.5 * $alert-icon-optical-padding);
   }
 }
 
 @each $name in $alerts {
-  .usa-alert--#{$name} .usa-alert__body::before {
-    left: $alert-icon-optical-padding;
-    top: units($theme-alert-padding-y) + units(0.5);
-  }
-}
+  .usa-alert--#{$name} .usa-alert__body {
+    padding-left: units($theme-alert-icon-size) + (1.5 * $alert-icon-optical-padding);
 
-.usa-alert--other {
-  background-color: color('primary-lighter');
-  border-left-color: color('primary-light');
-
-  .usa-alert__body {
-    padding-left: units($theme-alert-padding-x);
+    &::before {
+      left: $alert-icon-optical-padding;
+      top: units($theme-alert-padding-y) + units(0.5);
+    }
   }
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the Alert component styles to eliminate the custom `usa-alert--other` styles. This is intended to be backwards-compatible, where "Other" is intended to represent a stateless alert banner. This is already styled through USWDS as a slightly different shade of gray, and these changes help remove some confusion and extra code.

The concept of an "other" or default variant is already inherent to the idea of a BEM class "**B**lock", so it's redundant to have an explicit class. Technically it was already possible to use these styles with a `<div class="usa-alert">`, though it was never documented.

## 📜 Testing Plan

1. Go to http://localhost:4000/alerts/
2. Observe "Default" alert styles

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-design-system/assets/1779930/d44c6559-4a0a-452a-b99f-4da24924ea72)|![image](https://github.com/18F/identity-design-system/assets/1779930/5dcf9df1-7a65-4f25-a8ea-b70e2e54d390)
